### PR TITLE
[bugfix] deprecate batch interface setIsAtomic and modify releated test cases

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/mutation/BatchOperation.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/mutation/BatchOperation.java
@@ -34,7 +34,7 @@ public class BatchOperation {
     private Table        client;
     boolean              withResult;
     private List<Object> operations;
-    boolean              isAtomic = false;
+    boolean              isAtomic = true;
 
     /*
      * default constructor
@@ -96,6 +96,7 @@ public class BatchOperation {
         return this;
     }
 
+    @Deprecated
     public BatchOperation setIsAtomic(boolean isAtomic) {
         this.isAtomic = isAtomic;
         return this;

--- a/src/main/java/com/alipay/oceanbase/rpc/table/AbstractTableBatchOps.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/AbstractTableBatchOps.java
@@ -24,7 +24,7 @@ public abstract class AbstractTableBatchOps implements TableBatchOps {
 
     protected String            tableName;
 
-    protected boolean           atomicOperation;
+    protected boolean           atomicOperation = true;
 
     protected ObTableEntityType entityType = ObTableEntityType.DYNAMIC;
 
@@ -111,6 +111,7 @@ public abstract class AbstractTableBatchOps implements TableBatchOps {
      * Set atomic operation.
      */
     @Override
+    @Deprecated
     public void setAtomicOperation(boolean atomicOperation) {
         this.atomicOperation = atomicOperation;
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -245,12 +245,6 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
             obTableOperations.getRight().add(new ObPair<Integer, ObTableOperation>(i, operation));
         }
 
-        if (atomicOperation) {
-            if (partitionOperationsMap.size() > 1) {
-                throw new ObTablePartitionConsistentException(
-                    "require atomic operation but found across partition may cause consistent problem ");
-            }
-        }
         return partitionOperationsMap;
     }
 

--- a/src/main/java/com/alipay/oceanbase/rpc/table/api/TableBatchOps.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/api/TableBatchOps.java
@@ -28,6 +28,7 @@ public interface TableBatchOps {
 
     String getTableName();
 
+    @Deprecated
     void setAtomicOperation(boolean atomicOperation);
 
     boolean isAtomicOperation();

--- a/src/test/java/com/alipay/oceanbase/rpc/ObAtomicBatchOperationTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObAtomicBatchOperationTest.java
@@ -68,22 +68,6 @@ public class ObAtomicBatchOperationTest {
     @Test
     public void testAtomic() {
         TableBatchOps batchOps = obTableClient.batch("test_varchar_table");
-        // default: no atomic batch operation
-        try {
-            batchOps.clear();
-            batchOps.insert("abc-1", new String[] { "c2" }, new String[] { "bar-1" });
-            batchOps.get("abc-2", new String[] { "c2" });
-            batchOps.insert("abc-3", new String[] { "c2" }, new String[] { "bar-3" });
-            batchOps.insert(successKey, new String[] { "c2" }, new String[] { "bar-5" });
-            List<Object> results = batchOps.execute();
-            Assert.assertTrue(results.get(0) instanceof ObTableDuplicateKeyException);
-            Assert.assertEquals(((Map) results.get(1)).get("c2"), "xyz-2");
-            Assert.assertTrue(results.get(2) instanceof ObTableDuplicateKeyException);
-            Assert.assertEquals(results.get(3), 1L);
-        } catch (Exception ex) {
-            Assert.fail("hit exception:" + ex);
-        }
-
         // atomic batch operation
         try {
             batchOps.clear();

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
@@ -1956,34 +1956,6 @@ public class ObTableClientTest extends ObTableClientTestBase {
                 .addMutateColVal(colVal("c3", new byte[] { 1 }))
                 .addMutateColVal(colVal("c4", 103L)).execute();
 
-            Insert insert_0 = insert().setRowKey(row(colVal("c1", 0L), colVal("c2", "row_0")))
-                .addMutateColVal(colVal("c3", new byte[] { 1 }))
-                .addMutateColVal(colVal("c4", 100L));
-            Insert insert_1 = insert().setRowKey(row(colVal("c1", 4L), colVal("c2", "row_4")))
-                .addMutateColVal(colVal("c3", new byte[] { 1 }))
-                .addMutateColVal(colVal("c4", 104L));
-            Update update_0 = update().setRowKey(row(colVal("c1", 4L), colVal("c2", "row_4")))
-                .addMutateColVal(colVal("c3", new byte[] { 1 }))
-                .addMutateColVal(colVal("c4", 204L));
-            TableQuery query_0 = query().setRowKey(row(colVal("c1", 4L), colVal("c2", "row_4")))
-                .select("c3", "c4");
-
-            BatchOperationResult batchResult = client.batchOperation("test_mutation")
-                .addOperation(insert_0, insert_1, update_0).addOperation(query_0)
-                .setIsAtomic(false).execute();
-            Assert.assertEquals(1, batchResult.getWrongCount());
-            Assert.assertEquals(3, batchResult.getCorrectCount());
-            Assert.assertEquals(0, batchResult.getWrongIdx()[0]);
-            Assert.assertEquals(1, batchResult.getCorrectIdx()[0]);
-            Assert.assertEquals(1, batchResult.get(1).getAffectedRows());
-            Assert.assertEquals(1, batchResult.get(2).getAffectedRows());
-            OperationResult opResult = batchResult.get(3);
-            Assert.assertEquals(204L, opResult.getOperationRow().get("c4"));
-            Assert.assertEquals(204L, batchResult.get(3).getOperationRow().get("c4"));
-            opResult = batchResult.get(2);
-            Assert.assertNull(opResult.getOperationRow().get("c4"));
-            Assert.assertNull(batchResult.get(2).getOperationRow().get("c4"));
-
             long[] c1Vals = { 0L, 1L, 2L };
             String[] c2Vals = { "row_0", "row_1", "row_2" };
             byte[] c3Val = new byte[] { 1 };
@@ -2017,7 +1989,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
                 .addMutateColVal(colVal("c2", "row_1"))
                 .addMutateColVal(colVal("c3", new byte[] { 1 })).addMutateColVal(colVal("c4", 0L));
 
-            batchResult = client.batchOperation("test_mutation")
+            BatchOperationResult batchResult = client.batchOperation("test_mutation")
                 .addOperation(insert_2, update_1, iou_0).execute();
             Assert.assertEquals(0, batchResult.getWrongCount());
             Assert.assertEquals(3, batchResult.getCorrectCount());
@@ -2223,9 +2195,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
             Insert insert_1 = insert().setRowKey(row(colVal("c1", 400L), colVal("c2", "row_1")))
                 .addMutateColVal(colVal("c3", new byte[] { 1 }))
                 .addMutateColVal(colVal("c4", 100L));
-            BatchOperationResult result = batchOperation.addOperation(insert_0, insert_1)
-                .setIsAtomic(true).execute();
-            assertTrue(false);
+            BatchOperationResult result = batchOperation.addOperation(insert_0, insert_1).execute();
         } catch (Exception e) {
             e.printStackTrace();
             if (client instanceof ObTableClient && ((ObTableClient) client).isOdpMode()) {
@@ -2248,8 +2218,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
             Insert insert_1 = insert().setRowKey(row(colVal("c1", 200L), colVal("c2", "row_1")))
                 .addMutateColVal(colVal("c3", new byte[] { 1 }))
                 .addMutateColVal(colVal("c4", 100L));
-            BatchOperationResult result = batchOperation.addOperation(insert_0, insert_1)
-                .setIsAtomic(true).execute();
+            BatchOperationResult result = batchOperation.addOperation(insert_0, insert_1).execute();
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Deprecate the batch setIsAtomic interface and the batch operation is atomic now. Atomic means:
If one of the operation in a single-partition batch request execute failed, it will rollback and return error code.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
- Deprecate the batch setIsAtomic interface
- Modify atomic-related test case