### PR TITLE
fix: query with primary index fail when indexname specify to 'primary'

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -913,7 +913,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
     public String getIndexTableName(final String dataTableName, final String indexName, List<String> scanRangeColumns)
             throws Exception {
         String indexTableName = dataTableName;
-        if (indexName != null && !indexName.equals("PRIMARY")) {
+        if (indexName != null && !indexName.isEmpty() && !indexName.equalsIgnoreCase("PRIMARY")) {
             String tmpTableName = constructIndexTableName(dataTableName, indexName);
             if (tmpTableName == null) {
                 throw new ObTableException("index table name is null");

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -746,10 +746,10 @@ public class LocationUtil {
                 indexInfo.setIndexTableId(rs.getLong("table_id"));
                 indexInfo.setIndexType(ObIndexType.valueOf(rs.getInt("index_type")));
             } else {
-                throw new ObTableEntryRefreshException("fail to get index info from remote");
+                throw new ObTableEntryRefreshException("fail to get index info from remote, result set is empty");
             }
         } catch (Exception e) {
-            throw new ObTableEntryRefreshException("fail to get index info from remote", e);
+            throw new ObTableEntryRefreshException(format("fail to get index info from remote, indexTableName: %s", indexTableName), e);
         } finally {
             try {
                 if (null != rs) {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
bug:
when do query with primary index and specify the indexName with `primary`，the client will regard it is a secondary index and to judge if it is a global index.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
when indexName is NULL or is equal to 'primary' (ignore case), skip to judge if it is a global index