### PR TITLE
fix: use mysql driver by default to fix license incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,9 +121,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.oceanbase</groupId>
-            <artifactId>oceanbase-client</artifactId>
-            <version>2.4.3</version>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.28</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -244,7 +244,7 @@ public class LocationUtil {
     private static String formatObServerUrl(ObServerAddr obServerAddr, long connectTimeout,
                                             long socketTimeout) {
         return format(
-            "jdbc:oceanbase://%s/oceanbase?useUnicode=true&characterEncoding=utf-8&connectTimeout=%d&socketTimeout=%d",
+            "jdbc:mysql://%s/oceanbase?useUnicode=true&characterEncoding=utf-8&connectTimeout=%d&socketTimeout=%d",
             obServerAddr.getIp() + ":" + obServerAddr.getSqlPort(), connectTimeout, socketTimeout);
     }
 
@@ -258,11 +258,11 @@ public class LocationUtil {
     private static Connection getMetaRefreshConnection(String url, ObUserAuth sysUA)
                                                                                     throws ObTableEntryRefreshException {
         try {
-            Class.forName("com.alipay.oceanbase.jdbc.Driver");
+            Class.forName("com.mysql.cj.jdbc.Driver");
         } catch (ClassNotFoundException e) {
             RUNTIME.error(LCD.convert("01-00006"), e.getMessage(), e);
             throw new ObTableEntryRefreshException(format(
-                "fail to find com.alipay.oceanbase.jdbc.Driver, errMsg=%s", e.getMessage()), e);
+                "fail to find com.mysql.cj.jdbc.Driver, errMsg=%s", e.getMessage()), e);
         } catch (Exception e) {
             RUNTIME.error(LCD.convert("01-00005"), e.getMessage(), e);
             throw new ObTableEntryRefreshException("fail to decode proxyro password", e);

--- a/src/main/resources/oceanbase-table-client/log-codes.properties
+++ b/src/main/resources/oceanbase-table-client/log-codes.properties
@@ -3,7 +3,7 @@
 01-00003=Exception caught!
 01-00004=close obTable {} error
 01-00005=fail to decode proxyro password, errMsg={}
-01-00006=fail to find com.mysql.jdbc.Driver, key={}, errMsg={}
+01-00006=fail to find com.mysql.cj.jdbc.Driver, key={}, errMsg={}
 01-00007=fail to refresh table entry from remote url={}, key={}
 01-00008=table entry is invalid, addr = {}, key = {}, entry = {}
 01-00009=fail to get table entry from remote, key={}

--- a/src/test/java/com/alipay/oceanbase/rpc/containerBase/OceanBaseContainer.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/containerBase/OceanBaseContainer.java
@@ -72,7 +72,7 @@ public class OceanBaseContainer extends JdbcDatabaseContainer<OceanBaseContainer
 
     @Override
     public String getDriverClassName() {
-        return "com.oceanbase.jdbc.Driver";
+        return "com.mysql.cj.jdbc.Driver";
     }
 
     public Integer getSqlPort() {
@@ -90,7 +90,7 @@ public class OceanBaseContainer extends JdbcDatabaseContainer<OceanBaseContainer
 
     public String getJdbcUrl(String databaseName) {
         String additionalUrlParams = constructUrlParameters("?", "&");
-        return "jdbc:oceanbase://" + getHost() + ":" + getSqlPort() + "/" + databaseName
+        return "jdbc:mysql://" + getHost() + ":" + getSqlPort() + "/" + databaseName
                + additionalUrlParams;
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Ref: https://www.mysql.com/about/legal/licensing/foss-exception/

Mysql driver after 8.0.4 is compatible with OSI-approved licenses, which contains `MulanPSL-2.0`.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->

Replase `oceanbase-client` by mysql driver.