### PR TITLE
[Fix] the exception message when execute LS batch is inaccurate

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/mutation/BatchOperation.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/mutation/BatchOperation.java
@@ -207,7 +207,7 @@ public class BatchOperation {
                     }
                 } else {
                     throw new IllegalArgumentException(
-                        "the operation in LS batch must be checkAndInsUp");
+                        "The operations in batch must be all checkAndInsUp or all non-checkAndInsUp");
                 }
             }
         } else {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->
Fix the exception message when execute LS batch is inaccurate

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
