### PR TITLE
add option flag, batch operations can return one res

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObClusterTableBatchOps.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObClusterTableBatchOps.java
@@ -175,4 +175,10 @@ public class ObClusterTableBatchOps extends AbstractTableBatchOps {
         super.setAtomicOperation(atomicOperation);
         tableBatchOps.setAtomicOperation(atomicOperation);
     }
+
+    @Override
+    public void setReturnOneResult(boolean returnOneResult) {
+        super.setReturnOneResult(returnOneResult);
+        tableBatchOps.setReturnOneResult(returnOneResult);
+    }
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/mutation/BatchOperation.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/mutation/BatchOperation.java
@@ -37,6 +37,7 @@ public class BatchOperation {
     boolean              withResult;
     private List<Object> operations;
     boolean              isAtomic         = false;
+    boolean              returnOneResult  = false;
     boolean              hasCheckAndInsUp = false;
 
     /*
@@ -110,6 +111,11 @@ public class BatchOperation {
 
     public BatchOperation setIsAtomic(boolean isAtomic) {
         this.isAtomic = isAtomic;
+        return this;
+    }
+
+    public BatchOperation setReturnOneResult(boolean returnOneResult) {
+        this.returnOneResult = returnOneResult;
         return this;
     }
 
@@ -187,6 +193,7 @@ public class BatchOperation {
             }
         }
         batchOps.setAtomicOperation(isAtomic);
+        batchOps.setReturnOneResult(returnOneResult);
         return new BatchOperationResult(batchOps.executeWithResult());
     }
 

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableBatchOperation.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableBatchOperation.java
@@ -149,7 +149,9 @@ public class ObTableBatchOperation extends AbstractPayload {
         if (isSamePropertiesNames && length > 1) {
             ObTableOperation prev = tableOperations.get(length - 2);
             ObTableOperation curr = tableOperations.get(length - 1);
-            if (prev.getEntity().getPropertiesCount() != curr.getEntity().getPropertiesCount()) {
+            if (prev.getEntity() == null || curr.getEntity() == null) {
+                isSamePropertiesNames = false;
+            } else if (prev.getEntity().getPropertiesCount() != curr.getEntity().getPropertiesCount()) {
                 isSamePropertiesNames = false;
             } else {
                 isSamePropertiesNames =

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableBatchOperationRequest.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableBatchOperationRequest.java
@@ -161,4 +161,10 @@ public class ObTableBatchOperationRequest extends ObTableAbstractOperationReques
     public void setBatchOperationAsAtomic(boolean batchOperationAsAtomic) {
         this.batchOperationAsAtomic = batchOperationAsAtomic;
     }
+
+    public void setBatchOpReturnOneResult(boolean returnOneResult) {
+        if (returnOneResult == true) {
+            this.option_flag.setReturnOneResult(true);
+        }
+    }
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableOptionFlag.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableOptionFlag.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 public enum ObTableOptionFlag {
 
-    DEFAULT(0), RETURNING_ROWKEY(1 << 0), USE_PUT(1 << 1);
+    DEFAULT(0), RETURNING_ROWKEY(1 << 0), USE_PUT(1 << 1), RETURN_ONE_RES(1 << 2);
 
     private int                                    value;
     private static Map<Integer, ObTableOptionFlag> map = new HashMap<Integer, ObTableOptionFlag>();
@@ -87,6 +87,16 @@ public enum ObTableOptionFlag {
     public void setUsePut(boolean usePut) {
         if (usePut) {
             this.value |= USE_PUT.value;
+        }
+    }
+
+    public boolean isReturnOneResult() {
+        return (this.value & RETURN_ONE_RES.value) == 1;
+    }
+
+    public void setReturnOneResult(boolean returnOneResult) {
+        if (returnOneResult) {
+            this.value |= RETURN_ONE_RES.value;
         }
     }
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/AbstractTableBatchOps.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/AbstractTableBatchOps.java
@@ -25,6 +25,7 @@ public abstract class AbstractTableBatchOps implements TableBatchOps {
     protected String            tableName;
 
     protected boolean           atomicOperation;
+    protected boolean           returnOneResult;
 
     protected ObTableEntityType entityType = ObTableEntityType.DYNAMIC;
 
@@ -129,6 +130,19 @@ public abstract class AbstractTableBatchOps implements TableBatchOps {
     @Override
     public boolean isAtomicOperation() {
         return atomicOperation;
+    }
+
+    @Override
+    public void setReturnOneResult(boolean returnOneResult) {
+        this.returnOneResult = returnOneResult;
+    }
+
+    /*
+     * Is Return One Result.
+     */
+    @Override
+    public boolean isReturnOneResult() {
+        return returnOneResult;
     }
 
     /*

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableBatchOpsImpl.java
@@ -140,6 +140,7 @@ public class ObTableBatchOpsImpl extends AbstractTableBatchOps {
     public List<Object> execute() throws RemotingException, InterruptedException {
 
         request.setBatchOperationAsAtomic(isAtomicOperation());
+        request.setBatchOpReturnOneResult(isReturnOneResult());
         Object result = obTable.execute(request);
         checkObTableOperationResult(result);
 
@@ -173,6 +174,7 @@ public class ObTableBatchOpsImpl extends AbstractTableBatchOps {
     public List<Object> executeWithResult() throws Exception {
 
         request.setBatchOperationAsAtomic(isAtomicOperation());
+        request.setBatchOpReturnOneResult(isReturnOneResult());
         Object result = obTable.execute(request);
         checkObTableOperationResult(result);
 

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -300,6 +300,7 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
                 .toObTableConsistencyLevel());
         }
         subRequest.setBatchOperationAsAtomic(isAtomicOperation());
+        subRequest.setBatchOpReturnOneResult(isReturnOneResult());
         ObTableBatchOperationResult subObTableBatchOperationResult;
 
         boolean needRefreshTableEntry = false;

--- a/src/main/java/com/alipay/oceanbase/rpc/table/api/TableBatchOps.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/api/TableBatchOps.java
@@ -32,6 +32,10 @@ public interface TableBatchOps {
 
     boolean isAtomicOperation();
 
+    void setReturnOneResult(boolean returnOneResult);
+
+    boolean isReturnOneResult();
+
     void setEntityType(ObTableEntityType entityType);
 
     ObTableEntityType getEntityType();

--- a/src/test/java/com/alipay/oceanbase/rpc/ObAtomicBatchOperationTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObAtomicBatchOperationTest.java
@@ -63,6 +63,10 @@ public class ObAtomicBatchOperationTest {
             obTableClient.delete("test_varchar_table", key);
         }
         obTableClient.delete("test_varchar_table", successKey);
+        for (int i = 1; i <= 9; i++) {
+            String key = "abcd-" + i;
+            obTableClient.delete("test_varchar_table", key);
+        }
         obTableClient.close();
     }
 
@@ -190,4 +194,56 @@ public class ObAtomicBatchOperationTest {
 
     }
 
+    @Test
+    public void testReturnOneRes() {
+        TableBatchOps batchOps = obTableClient.batch("test_varchar_table");
+        // default: no ReturnOneRes batch operation
+        try {
+            batchOps.clear();
+            batchOps.insert("abcd-1", new String[] { "c2" }, new String[] { "returnOne-1" });
+            batchOps.insert("abcd-2", new String[] { "c2" }, new String[] { "returnOne-2" });
+            batchOps.insert("abcd-3", new String[] { "c2" }, new String[] { "returnOne-3" });
+            List<Object> results = batchOps.execute();
+            Assert.assertEquals(results.size(), 3);
+            Assert.assertEquals(results.get(0), 1L);
+            Assert.assertEquals(results.get(1), 1L);
+            Assert.assertEquals(results.get(2), 1L);
+        } catch (Exception ex) {
+            Assert.fail("hit exception:" + ex);
+        }
+
+        // no atomic ReturnOneRes batch operation
+        try {
+            batchOps.clear();
+            batchOps.setAtomicOperation(false);
+            batchOps.setReturnOneResult(true);
+            batchOps.insert("abcd-7", new String[] { "c2" }, new String[] { "returnOne-7" });
+            batchOps.insert("abcd-8", new String[] { "c2" }, new String[] { "returnOne-8" });
+            batchOps.insert("abcd-9", new String[] { "c2" }, new String[] { "returnOne-9" });
+            List<Object> results = batchOps.execute();
+            Assert.assertEquals(results.size(), 3);
+            Assert.assertEquals(results.get(0), 3L);
+            Assert.assertEquals(results.get(1), 3L);
+            Assert.assertEquals(results.get(2), 3L);
+        } catch (Exception ex) {
+            Assert.assertTrue(ex instanceof ObTableException);
+        }
+
+        // atomic ReturnOneRes batch operation
+        try {
+            batchOps.clear();
+            batchOps.setAtomicOperation(true);
+            batchOps.setReturnOneResult(true);
+            batchOps.insert("abcd-4", new String[] { "c2" }, new String[] { "returnOne-4" });
+            batchOps.insert("abcd-5", new String[] { "c2" }, new String[] { "returnOne-5" });
+            batchOps.insert("abcd-6", new String[] { "c2" }, new String[] { "returnOne-6" });
+            List<Object> results = batchOps.execute();
+            Assert.assertEquals(results.size(), 3);
+            Assert.assertEquals(results.get(0), 3L);
+            Assert.assertEquals(results.get(1), 3L);
+            Assert.assertEquals(results.get(2), 3L);
+        } catch (Exception ex) {
+            Assert.assertTrue(ex instanceof ObTableException);
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

batch operation add option flag to return one result, reduce the size of rpc package

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
1. add RETURN_ONE_RES in ObTableOptionFlag
