### PR TITLE
bugfixs: compress && rerouting not supported And global index route refresh wrong when retry

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -579,7 +579,6 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                     } else if (ex instanceof ObTableException
                                && ((ObTableException) ex).isNeedRefreshTableEntry()) {
                         needRefreshTableEntry = true;
-                        System.out.println("refresh entry in ObTableClient");
                         logger
                             .warn(
                                 "refresh table while meet Exception needing refresh, errorCode: {}, errorMsg: {}",

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -579,6 +579,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                     } else if (ex instanceof ObTableException
                                && ((ObTableException) ex).isNeedRefreshTableEntry()) {
                         needRefreshTableEntry = true;
+
                         logger
                             .warn(
                                 "refresh table while meet Exception needing refresh, errorCode: {}, errorMsg: {}",

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -579,7 +579,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                     } else if (ex instanceof ObTableException
                                && ((ObTableException) ex).isNeedRefreshTableEntry()) {
                         needRefreshTableEntry = true;
-
+                        System.out.println("refresh entry in ObTableClient");
                         logger
                             .warn(
                                 "refresh table while meet Exception needing refresh, errorCode: {}, errorMsg: {}",
@@ -784,6 +784,8 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                 tableName, runtimeContinuousFailureCeiling, errorMsg);
             getOrRefreshTableEntry(tableName, true, isTableEntryRefreshIntervalWait(), true);
             failures.set(0);
+        } else {
+            logger.warn("error msg: {}, current continues failure count: {}",  errorMsg, failures);
         }
     }
 

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/protocol/ObTablePacketCode.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/protocol/ObTablePacketCode.java
@@ -160,7 +160,6 @@ public enum ObTablePacketCode implements CommandCode {
             case Pcodes.OB_TABLE_API_LS_EXECUTE:
                 return OB_TABLE_API_LS_EXECUTE;
             case Pcodes.OB_TABLE_API_MOVE:
-                System.out.println("refresh entry in ObTablePacketCode");
                 throw new ObTableRoutingWrongException("Receive rerouting response packet. " +
                         "Java client is not supported and need to Refresh table router entry");
             case Pcodes.OB_ERROR_PACKET:

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/protocol/ObTablePacketCode.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/protocol/ObTablePacketCode.java
@@ -17,6 +17,7 @@
 
 package com.alipay.oceanbase.rpc.bolt.protocol;
 
+import com.alipay.oceanbase.rpc.exception.ObTableRoutingWrongException;
 import com.alipay.oceanbase.rpc.protocol.packet.ObRpcPacketHeader;
 import com.alipay.oceanbase.rpc.protocol.payload.ObPayload;
 import com.alipay.oceanbase.rpc.protocol.payload.Pcodes;
@@ -104,6 +105,16 @@ public enum ObTablePacketCode implements CommandCode {
             return new ObTableLSOpResult();
         }
     }, //
+    OB_TABLE_API_MOVE(Pcodes.OB_TABLE_API_MOVE) {
+        /**
+         * New payload.
+         */
+        @Override
+        public ObPayload newPayload(ObRpcPacketHeader header) {
+            throw new ObTableRoutingWrongException("Receive rerouting response packet. " +
+                    "Java client is not supported and need to Refresh table router entry");
+        }
+    }, //
     OB_ERROR_PACKET(Pcodes.OB_ERROR_PACKET) {
         /*
          * New payload.
@@ -148,6 +159,10 @@ public enum ObTablePacketCode implements CommandCode {
                 return OB_TABLE_API_DIRECT_LOAD;
             case Pcodes.OB_TABLE_API_LS_EXECUTE:
                 return OB_TABLE_API_LS_EXECUTE;
+            case Pcodes.OB_TABLE_API_MOVE:
+                System.out.println("refresh entry in ObTablePacketCode");
+                throw new ObTableRoutingWrongException("Receive rerouting response packet. " +
+                        "Java client is not supported and need to Refresh table router entry");
             case Pcodes.OB_ERROR_PACKET:
                 return OB_ERROR_PACKET;
         }

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
@@ -19,10 +19,8 @@ package com.alipay.oceanbase.rpc.bolt.transport;
 
 import com.alipay.oceanbase.rpc.bolt.protocol.ObTablePacket;
 import com.alipay.oceanbase.rpc.bolt.protocol.ObTablePacketCode;
-import com.alipay.oceanbase.rpc.exception.ExceptionUtil;
-import com.alipay.oceanbase.rpc.exception.ObTableLoginException;
-import com.alipay.oceanbase.rpc.exception.ObTableRoutingWrongException;
-import com.alipay.oceanbase.rpc.exception.ObTableUnexpectedException;
+import com.alipay.oceanbase.rpc.exception.*;
+import com.alipay.oceanbase.rpc.protocol.packet.ObCompressType;
 import com.alipay.oceanbase.rpc.protocol.payload.AbstractPayload;
 import com.alipay.oceanbase.rpc.protocol.payload.Credentialable;
 import com.alipay.oceanbase.rpc.protocol.payload.ObPayload;
@@ -34,6 +32,9 @@ import com.alipay.remoting.*;
 import com.alipay.remoting.exception.RemotingException;
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
+
+import static com.alipay.oceanbase.rpc.protocol.packet.ObCompressType.INVALID_COMPRESSOR;
+import static com.alipay.oceanbase.rpc.protocol.packet.ObCompressType.NONE_COMPRESSOR;
 
 public class ObTableRemoting extends BaseRemoting {
 
@@ -93,9 +94,14 @@ public class ObTableRemoting extends BaseRemoting {
         try {
             // decode packet header first
             response.decodePacketHeader();
-
+            ObCompressType compressType = response.getHeader().getObCompressType();
+            if (compressType != INVALID_COMPRESSOR && compressType != NONE_COMPRESSOR) {
+                String errMessage = TraceUtil.formatTraceMessage(conn, request,
+                        "Rpc Result is compressed. Java Client is not supported. msg:" + response.getMessage());
+                logger.warn(errMessage);
+                throw new FeatureNotSupportedException(errMessage);
+            }
             ByteBuf buf = response.getPacketContentBuf();
-
             // If response indicates the request is routed to wrong server, we should refresh the routing meta.
             if (response.getHeader().isRoutingWrong()) {
                 String errMessage = TraceUtil.formatTraceMessage(conn, request,

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/Pcodes.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/Pcodes.java
@@ -31,5 +31,6 @@ public interface Pcodes {
     int OB_TABLE_API_EXECUTE_QUERY_SYNC = 0x1106;
 
     int OB_TABLE_API_DIRECT_LOAD        = 0x1123;
+    int OB_TABLE_API_MOVE               = 0x1124;
     int OB_TABLE_API_LS_EXECUTE         = 0x1125;
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -51,6 +51,10 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
     protected ObTableQuery                                                     tableQuery;
     protected long                                                             operationTimeout    = -1;
     protected String                                                           tableName;
+    // use to store the TableEntry Key:
+    // primary index or local index: key is primary table name
+    // global index: key is index table name (be like: __idx_<data_table_id>_<index_name>)
+    protected String                                                           indexTableName;
     protected ObTableEntityType                                                entityType;
     private Map<Long, ObPair<Long, ObTableParam>>                              expectant;                                                                                     // Map<logicId, ObPair<logicId, param>>
     private List<String>                                                       cacheProperties     = new LinkedList<String>();
@@ -430,6 +434,16 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
     public void setTableName(String tableName) {
         this.tableName = tableName;
     }
+
+    /*
+     * Get index table name.
+     */
+    public String getIndexTableName() { return indexTableName; }
+
+    /*
+     * Set index table name.
+     */
+    public void setIndexTableName(String indexTableName) { this.indexTableName = indexTableName; }
 
     /*
      * Get entity type.

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryStreamResult.java
@@ -86,7 +86,6 @@ public class ObTableClientQueryStreamResult extends AbstractQueryStreamResult {
                 client.resetExecuteContinuousFailureCount(indexTableName);
                 break;
             } catch (Exception e) {
-                System.out.println("indexTableName:" + indexTableName);
                 if (client.isOdpMode()) {
                     if ((tryTimes - 1) < client.getRuntimeRetryTimes()) {
                         if (e instanceof ObTableException) {

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryStreamResult.java
@@ -77,33 +77,34 @@ public class ObTableClientQueryStreamResult extends AbstractQueryStreamResult {
                             route.setBlackList(failedServerList);
                         }
                         subObTable = client
-                            .getTable(tableName, partIdWithIndex.getLeft(), needRefreshTableEntry,
+                            .getTable(indexTableName, partIdWithIndex.getLeft(), needRefreshTableEntry,
                                 client.isTableEntryRefreshIntervalWait(), route).getRight()
                             .getObTable();
                     }
                 }
                 result = subObTable.execute(request);
-                client.resetExecuteContinuousFailureCount(tableName);
+                client.resetExecuteContinuousFailureCount(indexTableName);
                 break;
             } catch (Exception e) {
+                System.out.println("indexTableName:" + indexTableName);
                 if (client.isOdpMode()) {
                     if ((tryTimes - 1) < client.getRuntimeRetryTimes()) {
                         if (e instanceof ObTableException) {
                             logger
                                 .warn(
                                     "tablename:{} stream query execute while meet Exception needing retry, errorCode: {}, errorMsg: {}, try times {}",
-                                    tableName, ((ObTableException) e).getErrorCode(),
+                                    indexTableName, ((ObTableException) e).getErrorCode(),
                                     e.getMessage(), tryTimes);
                         } else if (e instanceof IllegalArgumentException) {
                             logger
                                 .warn(
                                     "tablename:{} stream query execute while meet Exception needing retry, try times {}, errorMsg: {}",
-                                    tableName, tryTimes, e.getMessage());
+                                    indexTableName, tryTimes, e.getMessage());
                         } else {
                             logger
                                 .warn(
                                     "tablename:{} stream query execute while meet Exception needing retry, try times {}",
-                                    tableName, tryTimes, e);
+                                    indexTableName, tryTimes, e);
                         }
                     } else {
                         throw e;
@@ -113,7 +114,7 @@ public class ObTableClientQueryStreamResult extends AbstractQueryStreamResult {
                         if ((tryTimes - 1) < client.getRuntimeRetryTimes()) {
                             logger.warn(
                                 "tablename:{} partition id:{} retry when replica not readable: {}",
-                                tableName, partIdWithIndex.getLeft(), e.getMessage(), e);
+                                indexTableName, partIdWithIndex.getLeft(), e.getMessage(), e);
                             if (failedServerList == null) {
                                 failedServerList = new HashSet<String>();
                             }
@@ -122,7 +123,7 @@ public class ObTableClientQueryStreamResult extends AbstractQueryStreamResult {
                             logger
                                 .warn(
                                     "tablename:{} partition id:{} exhaust retry when replica not readable: {}",
-                                    tableName, partIdWithIndex.getLeft(), e.getMessage(), e);
+                                     indexTableName, partIdWithIndex.getLeft(), e.getMessage(), e);
                             throw e;
                         }
                     } else if (e instanceof ObTableException
@@ -131,21 +132,21 @@ public class ObTableClientQueryStreamResult extends AbstractQueryStreamResult {
                         logger
                             .warn(
                                 "tablename:{} partition id:{} stream query refresh table while meet Exception needing refresh, errorCode: {}",
-                                tableName, partIdWithIndex.getLeft(),
+                                 indexTableName, partIdWithIndex.getLeft(),
                                 ((ObTableException) e).getErrorCode(), e);
                         if (client.isRetryOnChangeMasterTimes()
                             && (tryTimes - 1) < client.getRuntimeRetryTimes()) {
                             logger
                                 .warn(
                                     "tablename:{} partition id:{} stream query retry while meet Exception needing refresh, errorCode: {} , retry times {}",
-                                    tableName, partIdWithIndex.getLeft(),
+                                    indexTableName, partIdWithIndex.getLeft(),
                                     ((ObTableException) e).getErrorCode(), tryTimes, e);
                         } else {
-                            client.calculateContinuousFailure(tableName, e.getMessage());
+                            client.calculateContinuousFailure(indexTableName, e.getMessage());
                             throw e;
                         }
                     } else {
-                        client.calculateContinuousFailure(tableName, e.getMessage());
+                        client.calculateContinuousFailure(indexTableName, e.getMessage());
                         throw e;
                     }
                 }

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/async/ObTableClientQueryAsyncStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/async/ObTableClientQueryAsyncStreamResult.java
@@ -68,11 +68,11 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
             try {
                 if (needRefreshTableEntry) {
                     subObTable = client
-                        .getTable(tableName, new Long[] { partIdWithObTable.getLeft() }, true,
+                        .getTable(indexTableName, new Long[] { partIdWithObTable.getLeft() }, true,
                             client.isTableEntryRefreshIntervalWait()).getRight().getObTable();
                 }
                 result = subObTable.execute(streamRequest);
-                client.resetExecuteContinuousFailureCount(tableName);
+                client.resetExecuteContinuousFailureCount(indexTableName);
                 break;
             } catch (Exception e) {
                 if (e instanceof ObTableException
@@ -89,11 +89,11 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
                                 "stream query retry while meet ObTableMasterChangeException, errorCode: {} , retry times {}",
                                 ((ObTableException) e).getErrorCode(), tryTimes);
                     } else {
-                        client.calculateContinuousFailure(tableName, e.getMessage());
+                        client.calculateContinuousFailure(indexTableName, e.getMessage());
                         throw e;
                     }
                 } else {
-                    client.calculateContinuousFailure(tableName, e.getMessage());
+                    client.calculateContinuousFailure(indexTableName, e.getMessage());
                     throw e;
                 }
             }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/AbstractTableQueryImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/AbstractTableQueryImpl.java
@@ -31,6 +31,8 @@ import java.util.List;
 public abstract class AbstractTableQueryImpl extends AbstractTableQuery {
 
     protected ObTableQuery tableQuery;
+    // TableEntry key
+    protected String indexTableName;
 
     /*
      * Select.
@@ -180,5 +182,13 @@ public abstract class AbstractTableQueryImpl extends AbstractTableQuery {
     public TableQuery setMaxResultSize(long maxResultSize) {
         this.tableQuery.setMaxResultSize(maxResultSize);
         return this;
+    }
+
+    public String getIndexTableName() {
+        return indexTableName;
+    }
+
+    public void setIndexTableName(String indexTableName) {
+        this.indexTableName = indexTableName;
     }
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryAsyncImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryAsyncImpl.java
@@ -45,6 +45,7 @@ public class ObTableClientQueryAsyncImpl extends AbstractTableQueryImpl {
 
     public ObTableClientQueryAsyncImpl(String tableName, ObTableClient client) {
         this.tableName = tableName;
+        this.indexTableName = tableName;
         this.obTableClient = client;
         this.tableQuery = new ObTableQuery();
     }
@@ -52,6 +53,7 @@ public class ObTableClientQueryAsyncImpl extends AbstractTableQueryImpl {
     public ObTableClientQueryAsyncImpl(String tableName, ObTableQuery tableQuery,
                                        ObTableClient client) {
         this.tableName = tableName;
+        this.indexTableName = tableName;
         this.obTableClient = client;
         this.tableQuery = tableQuery;
     }
@@ -112,6 +114,7 @@ public class ObTableClientQueryAsyncImpl extends AbstractTableQueryImpl {
         obTableClientQueryASyncStreamResult.setTableQuery(tableQuery);
         obTableClientQueryASyncStreamResult.setEntityType(entityType);
         obTableClientQueryASyncStreamResult.setTableName(tableName);
+        obTableClientQueryASyncStreamResult.setIndexTableName(indexTableName);
         obTableClientQueryASyncStreamResult.setExpectant(partitionObTables);
         obTableClientQueryASyncStreamResult.setOperationTimeout(operationTimeout);
         obTableClientQueryASyncStreamResult.setClient(obTableClient);
@@ -134,6 +137,7 @@ public class ObTableClientQueryAsyncImpl extends AbstractTableQueryImpl {
         obTableClientQueryASyncStreamResult.setTableQuery(tableQuery);
         obTableClientQueryASyncStreamResult.setEntityType(entityType);
         obTableClientQueryASyncStreamResult.setTableName(tableName);
+        obTableClientQueryASyncStreamResult.setIndexTableName(indexTableName);
         obTableClientQueryASyncStreamResult.setExpectant(partitionObTables);
         obTableClientQueryASyncStreamResult.setOperationTimeout(operationTimeout);
         obTableClientQueryASyncStreamResult.setClient(obTableClient);
@@ -151,7 +155,6 @@ public class ObTableClientQueryAsyncImpl extends AbstractTableQueryImpl {
 
     public Map<Long, ObPair<Long, ObTableParam>> getPartitions() throws Exception {
         String indexName = tableQuery.getIndexName();
-        String indexTableName = tableName;
         if (!this.obTableClient.isOdpMode()) {
             indexTableName = obTableClient.getIndexTableName(tableName, indexName,
                 tableQuery.getScanRangeColumns());

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
@@ -54,6 +54,7 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
      */
     public ObTableClientQueryImpl() {
         this.tableName = null;
+        this.indexTableName = null;
         this.obTableClient = null;
         this.tableQuery = new ObTableQuery();
         this.rowKey = null;
@@ -64,6 +65,7 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
      */
     public ObTableClientQueryImpl(String tableName, ObTableClient client) {
         this.tableName = tableName;
+        this.indexTableName = tableName;
         this.obTableClient = client;
         this.tableQuery = new ObTableQuery();
         this.rowKey = null;
@@ -74,6 +76,7 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
      */
     public ObTableClientQueryImpl(String tableName, ObTableQuery tableQuery, ObTableClient client) {
         this.tableName = tableName;
+        this.indexTableName = tableName;
         this.obTableClient = client;
         this.tableQuery = tableQuery;
         this.rowKey = null;
@@ -144,7 +147,6 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
                 obTableClient.getOdpTable())));
         } else {
             String indexName = tableQuery.getIndexName();
-            String indexTableName = tableName;
             if (!this.obTableClient.isOdpMode()) {
                 indexTableName = obTableClient.getIndexTableName(tableName, indexName,
                     tableQuery.getScanRangeColumns());
@@ -196,6 +198,7 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
         obTableClientQueryStreamResult.setTableQuery(tableQuery);
         obTableClientQueryStreamResult.setEntityType(entityType);
         obTableClientQueryStreamResult.setTableName(tableName);
+        obTableClientQueryStreamResult.setIndexTableName(indexTableName);
         obTableClientQueryStreamResult.setExpectant(partitionObTables);
         obTableClientQueryStreamResult.setClient(obTableClient);
         obTableClientQueryStreamResult.setOperationTimeout(operationTimeout);

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
@@ -2498,7 +2498,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
                     new Object[]{new byte[]{1}, "row1"});
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("table name is null",
-                   ((IllegalArgumentException) e).getMessage());
+                    ((IllegalArgumentException) e).getMessage());
         }
         try {
             TableQuery tableQuery = client.query("");
@@ -2507,7 +2507,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
             QueryResultSet result = tableQuery.execute();
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("table name is null",
-                   ((IllegalArgumentException) e).getMessage());
+                    ((IllegalArgumentException) e).getMessage());
         }
         // test insertOrUpdate
         final ObTableClient client1 = ObTableClientTestUtil.newTestClient();
@@ -2518,13 +2518,13 @@ public class ObTableClientTest extends ObTableClientTestBase {
             long lastTime = getMaxAccessTime(client1);
             Thread.sleep(10000);
             // test_query_filter_mutate
-            client1.insertOrUpdate("", "foo", new String[] { "c2" },
-                new String[] { "bar" });
+            client1.insertOrUpdate("", "foo", new String[]{"c2"},
+                    new String[]{"bar"});
             long nowTime = getMaxAccessTime(client1);
             Assert.assertTrue(nowTime - lastTime > 8000);
-        }  catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             Assert.assertEquals("table name is null",
-                   ((IllegalArgumentException) e).getMessage());
+                    ((IllegalArgumentException) e).getMessage());
         }
     }
 }

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
@@ -2498,7 +2498,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
                     new Object[]{new byte[]{1}, "row1"});
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("table name is null",
-                    ((IllegalArgumentException) e).getMessage());
+                   ((IllegalArgumentException) e).getMessage());
         }
         try {
             TableQuery tableQuery = client.query("");
@@ -2507,7 +2507,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
             QueryResultSet result = tableQuery.execute();
         } catch (IllegalArgumentException e) {
             Assert.assertEquals("table name is null",
-                    ((IllegalArgumentException) e).getMessage());
+                   ((IllegalArgumentException) e).getMessage());
         }
         // test insertOrUpdate
         final ObTableClient client1 = ObTableClientTestUtil.newTestClient();
@@ -2518,13 +2518,12 @@ public class ObTableClientTest extends ObTableClientTestBase {
             long lastTime = getMaxAccessTime(client1);
             Thread.sleep(10000);
             // test_query_filter_mutate
-            client1.insertOrUpdate("", "foo", new String[]{"c2"},
-                    new String[]{"bar"});
+            client1.insertOrUpdate("", "foo", new String[] { "c2" },
+                    new String[] { "bar" });
             long nowTime = getMaxAccessTime(client1);
             Assert.assertTrue(nowTime - lastTime > 8000);
-        } catch (IllegalArgumentException e) {
+        }  catch (IllegalArgumentException e) {
             Assert.assertEquals("table name is null",
-                    ((IllegalArgumentException) e).getMessage());
-        }
+                   ((IllegalArgumentException) e).getMessage());        }
     }
 }

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
@@ -2519,11 +2519,12 @@ public class ObTableClientTest extends ObTableClientTestBase {
             Thread.sleep(10000);
             // test_query_filter_mutate
             client1.insertOrUpdate("", "foo", new String[] { "c2" },
-                    new String[] { "bar" });
+                new String[] { "bar" });
             long nowTime = getMaxAccessTime(client1);
             Assert.assertTrue(nowTime - lastTime > 8000);
         }  catch (IllegalArgumentException e) {
             Assert.assertEquals("table name is null",
-                   ((IllegalArgumentException) e).getMessage());        }
+                   ((IllegalArgumentException) e).getMessage());
+        }
     }
 }

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableGlobalIndexTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableGlobalIndexTest.java
@@ -437,7 +437,7 @@ public class ObTableGlobalIndexTest {
             Assert.assertEquals(resultSet4.cacheSize(), recordCount);
             count = 0;
             while (resultSet4.next()) {
-                Map<String, Object> row = resultSet2.getRow();
+                Map<String, Object> row = resultSet4.getRow();
                 int c1 = (int) row.get("C1");
                 int c2 = (int) row.get("C2");
                 int c3 = (int) row.get("C3");


### PR DESCRIPTION

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
bugfixs:
1. client return "Unknown Rpc command code value ,4388" when observer and client enable rerouting
2. java client  cannot support rpc result compressed
3. global index route refresh wrong when need to retry refresh table entry


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
