### PR TITLE
remove addRowkeyElement in mutation op

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObRangePartDesc.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObRangePartDesc.java
@@ -216,7 +216,7 @@ public class ObRangePartDesc extends ObPartDesc {
     }
 
     public int getBoundsIdx(Object... rowKey) {
-        if (rowKey.length != rowKeyElement.size()) {
+        if (rowKey.length < rowKeyElement.size()) {
             throw new IllegalArgumentException("row key is consist of " + rowKeyElement
                                                + "but found" + Arrays.toString(rowKey));
         }

--- a/src/main/java/com/alipay/oceanbase/rpc/mutation/BatchOperation.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/mutation/BatchOperation.java
@@ -127,17 +127,10 @@ public class BatchOperation {
             throw new IllegalArgumentException("table name is null");
         }
         TableBatchOps batchOps = client.batch(tableName);
-        boolean hasSetRowkeyElement = false;
 
         for (Object operation : operations) {
             if (operation instanceof Mutation) {
                 Mutation mutation = (Mutation) operation;
-                if (!hasSetRowkeyElement && mutation.getRowKeyNames() != null) {
-                    List<String> rowKeyNames = mutation.getRowKeyNames();
-                    ((ObTableClient) client).addRowKeyElement(tableName,
-                        rowKeyNames.toArray(new String[0]));
-                    hasSetRowkeyElement = true;
-                }
                 ObTableOperationType type = mutation.getOperationType();
                 switch (type) {
                     case GET:
@@ -200,17 +193,11 @@ public class BatchOperation {
         ObTableClientLSBatchOpsImpl batchOps;
         if (client instanceof ObTableClient) {
             batchOps = new ObTableClientLSBatchOpsImpl(tableName, (ObTableClient) client);
-            boolean hasSetRowkeyElement = false;
             for (Object operation : operations) {
                 if (operation instanceof CheckAndInsUp) {
                     CheckAndInsUp checkAndInsUp = (CheckAndInsUp) operation;
                     batchOps.addOperation(checkAndInsUp);
                     List<String> rowKeyNames = checkAndInsUp.getInsUp().getRowKeyNames();
-                    if (!hasSetRowkeyElement && rowKeyNames != null) {
-                        ((ObTableClient) client).addRowKeyElement(tableName,
-                            rowKeyNames.toArray(new String[0]));
-                        hasSetRowkeyElement = true;
-                    }
                 } else {
                     throw new IllegalArgumentException(
                         "The operations in batch must be all checkAndInsUp or all non-checkAndInsUp");

--- a/src/main/java/com/alipay/oceanbase/rpc/mutation/Mutation.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/mutation/Mutation.java
@@ -179,12 +179,6 @@ public class Mutation<T> {
         this.rowKey = Keys.toArray();
         this.rowKeyNames = columnNames;
 
-        // set row key in table
-        if (null != tableName) {
-            ((ObTableClient) client)
-                .addRowKeyElement(tableName, columnNames.toArray(new String[0]));
-        }
-
         // renew scan range of QueryAndMutate
         if (null != query) {
             query.addScanRange(this.rowKey, this.rowKey);
@@ -217,12 +211,6 @@ public class Mutation<T> {
         this.rowKey = Keys.toArray();
         this.rowKeyNames = columnNames;
 
-        // set row key in table
-        if (null != tableName) {
-            ((ObTableClient) client)
-                .addRowKeyElement(tableName, columnNames.toArray(new String[0]));
-        }
-
         hasSetRowKey = true;
         return (T) this;
     }
@@ -250,12 +238,6 @@ public class Mutation<T> {
         }
         this.rowKey = Keys.toArray();
         this.rowKeyNames = columnNames;
-
-        // set row key in table
-        if (null != tableName) {
-            ((ObTableClient) client)
-                .addRowKeyElement(tableName, columnNames.toArray(new String[0]));
-        }
 
         // renew scan range of QueryAndMutate
         if (null != query) {
@@ -289,12 +271,6 @@ public class Mutation<T> {
         }
         this.rowKey = Keys.toArray();
         this.rowKeyNames = columnNames;
-
-        // set row key in table
-        if (null != tableName) {
-            ((ObTableClient) client)
-                .addRowKeyElement(tableName, columnNames.toArray(new String[0]));
-        }
 
         hasSetRowKey = true;
         return (T) this;
@@ -358,13 +334,7 @@ public class Mutation<T> {
         query.setScanRangeColumns(columnNames);
 
         // set row key in table
-        if (null != tableName && null != client) {
-            if (!((ObTableClient) client).isOdpMode()) {
-                // TODO: adapt OCP
-                //      OCP must conclude all rowkey now
-                ((ObTableClient) client).addRowKeyElement(tableName, columnNames);
-            }
-        } else {
+        if (null == tableName || null == client) {
             throw new ObTableException("invalid table name: " + tableName + ", or invalid client: "
                                        + client + " while setting scan range columns");
         }

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableCheckAndInsUpTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableCheckAndInsUpTest.java
@@ -53,6 +53,8 @@ public class ObTableCheckAndInsUpTest {
         final ObTableClient obTableClient = ObTableClientTestUtil.newTestClient();
         obTableClient.init();
         this.client = obTableClient;
+        client.addRowKeyElement(TABLE_NAME, new String[] {"c1"});
+
     }
 
     private boolean isVersionSupported() {
@@ -230,6 +232,7 @@ public class ObTableCheckAndInsUpTest {
         String testTable = "test_mutation_column_reverse";
 
         try {
+            client.addRowKeyElement(testTable, new String[] {"c2"});
             // 1. check exists match: insup (c2, c1, c3, c4) (5, 'c2_v0', c3_v0, 100) if not exists c3 is not null;
             InsertOrUpdate insertOrUpdate1 = new InsertOrUpdate();
             insertOrUpdate1.setRowKey(row(colVal("c2", 5L), colVal("c1", "c2_v0")));

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableClientCheckAndInsertTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableClientCheckAndInsertTest.java
@@ -68,7 +68,7 @@ public class ObTableClientCheckAndInsertTest extends ObTableClientTestBase {
         }
 
         final String TABLE_NAME = "test_mutation";
-
+        ((ObTableClient) client).addRowKeyElement(TABLE_NAME, new String[] {"c1"});
         TableQuery tableQuery = client.query(TABLE_NAME);
         tableQuery.addScanRange(new Object[] { 0L, "\0" }, new Object[] { 200L, "\254" });
         tableQuery.select("c1", "c2", "c3", "c4");

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
@@ -1652,6 +1652,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
     @Test
     public void testMutation() throws Exception {
         System.setProperty("ob_table_min_rslist_refresh_interval_millis", "1");
+        ((ObTableClient) client).addRowKeyElement("test_mutation", new String[] {"c1"});
 
         TableQuery tableQuery = client.query("test_mutation");
         tableQuery.addScanRange(new Object[] { 0L, "\0" }, new Object[] { 200L, "\254" });
@@ -1908,6 +1909,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
     @Test
     public void testPut() throws Exception {
         System.setProperty("ob_table_min_rslist_refresh_interval_millis", "1");
+        ((ObTableClient) client).addRowKeyElement("test_mutation", new String[] {"c1"});
         try {
             // put
             MutationResult insertOrUpdateResult = client.put("test_mutation")
@@ -1941,7 +1943,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
     @Test
     public void testBatchMutation() throws Exception {
         System.setProperty("ob_table_min_rslist_refresh_interval_millis", "1");
-
+        ((ObTableClient) client).addRowKeyElement("test_mutation", new String[] {"c1"});
         TableQuery tableQuery = client.query("test_mutation");
         tableQuery.addScanRange(new Object[] { 0L, "\0" }, new Object[] { 200L, "\254" });
         tableQuery.select("c1", "c2", "c3", "c4");
@@ -2221,6 +2223,7 @@ public class ObTableClientTest extends ObTableClientTestBase {
     public void testAtomicBatchMutation() throws Exception {
         try {
             // atomic batch operation can not span partitions
+            ((ObTableClient) client).addRowKeyElement("test_mutation", new String[] {"c1"});
             BatchOperation batchOperation = client.batchOperation("test_mutation");
             Insert insert_0 = insert().setRowKey(row(colVal("c1", 100L), colVal("c2", "row_0")))
                 .addMutateColVal(colVal("c3", new byte[] { 1 }))
@@ -2333,6 +2336,8 @@ public class ObTableClientTest extends ObTableClientTestBase {
 
         try {
             cleanTable("cse_index_1");
+            ((ObTableClient) client).addRowKeyElement("cse_index_1", new String[] {"measurement"});
+
             // prepare data with insert
             Insert insert_0 = insert().setRowKey(
                 row(colVal("measurement", "measurement1"), colVal("tag_key", "tag_key1"),

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableGlobalIndexTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableGlobalIndexTest.java
@@ -539,6 +539,7 @@ public class ObTableGlobalIndexTest {
         String prefixKey = "test";
         long[] keyIds = { 1L, 2L };
         try {
+            ((ObTableClient) client).addRowKeyElement(tableName, new String[] {"c1"});
             // 1. insert records with null expired_ts
             for (long id : keyIds) {
                 client.insert(tableName).setRowKey(colVal(rowKey1, prefixKey), colVal(rowKey2, id))


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
remove addRowkeyElement in mutation interface


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
In mutation interface, there will call addRowkeyElement implicit. This will caused error in scene following:
```
create table test_demo (
 c1 int not null,
 c2 int not null,
 c3 varchar(255) not null,
 primary(c1,c2),
 key idx(c1, c3) local) partition by key(c1) partitions 3;
```
tableapi case:
```
String tableName = "test_demo"
// insert with mutate
Row rowKey = row(colVal("c1", 1), colVal("c2", "c2_col")));
Row row = row();
row.add(colVal("c3", "c3_col"));
client.insert(tableName).setRowKey(rowKey).addMutateRow(row).execute();

// query with local by old interface
// it will cause exception:
TableQuery query = client.query(tableName).indexName("idx").setScanRangeColumns("c1", "c3");
query.addScanRange(new Object[]{1, ObObj.getMin()}, new Object[]{"1", ObObj.getMax()});
QueryResultSet resultSet = query.execute()

```
In table `test_demo`，the partition key is `"c1"`, and the `addRowkeyElement` must be set as `"c1"` so that the query can be executed. But in mutation interface, it will call addRowkeyElement and set it to `"c1,c2"` which cause query execution throw exception.
In this PR, we remove `addRowkeyElement` in mutation interface and user must call addRowkeyElement  to set the partion key before doing operation, like following case:
```
String tableName = "test_demo"
 ((ObTableClient) client).addRowKeyElement(tableName, new String[]{"c1"});
// insert with mutate
Row rowKey = row(colVal("c1", 1), colVal("c2", "c2_col")));
Row row = row();
row.add(colVal("c3", "c3_col"));
client.insert(tableName).setRowKey(rowKey).addMutateRow(row).execute();

TableQuery query = client.query(tableName).indexName("idx").setScanRangeColumns("c1", "c3");
query.addScanRange(new Object[]{1, ObObj.getMin()}, new Object[]{"1", ObObj.getMax()});
QueryResultSet resultSet = query.execute()

```