### PR TITLE
Fix isSamePropertiesNames flag in ObTableTabletOp is wrong

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableTabletOp.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableTabletOp.java
@@ -126,15 +126,29 @@ public class ObTableTabletOp extends AbstractPayload {
      */
     public void setSingleOperations(List<ObTableSingleOp> singleOperations) {
         setIsSameType(true);
+        setIsSamePropertiesNames(true);
         ObTableOperationType prevType = null;
+        List<String> prevPropertiesNames = null;
         for (ObTableSingleOp o : singleOperations) {
             // get union column names
             rowKeyNamesSet.addAll(o.getQuery().getScanRangeColumns());
             for (ObTableSingleOpEntity e: o.getEntities()) {
                 rowKeyNamesSet.addAll(e.getRowKeyNames());
                 propertiesNamesSet.addAll(e.getPropertiesNames());
+
+                if (!isSamePropertiesNames()) {
+                    // do nothing
+                } else if (prevPropertiesNames != null && isSamePropertiesNames() &&
+                        !prevPropertiesNames.equals(e.getPropertiesNames())) {
+                    setIsSamePropertiesNames(false);
+                } else {
+                    prevPropertiesNames = e.getPropertiesNames();
+                }
             }
-            if (prevType != null && prevType != o.getSingleOpType()) {
+
+            if (!isSameType()) {
+                // do nothing
+            } else if (prevType != null && prevType != o.getSingleOpType()) {
                 setIsSameType(false);
             } else {
                 prevType = o.getSingleOpType();
@@ -157,9 +171,17 @@ public class ObTableTabletOp extends AbstractPayload {
 
     public boolean isSameType() { return optionFlag.getFlagIsSameType(); }
 
+    public boolean isSamePropertiesNames() {
+        return optionFlag.getFlagIsSamePropertiesNames();
+    }
+
     public void setIsSameType(boolean isSameType) { optionFlag.setFlagIsSameType(isSameType);}
 
     public void setIsReadOnly(boolean isReadOnly) { optionFlag.setFlagIsReadOnly(isReadOnly);}
+
+    public void setIsSamePropertiesNames(boolean isSamePropertiesNames) {
+        optionFlag.setFlagIsSamePropertiesNames(isSamePropertiesNames);
+    }
 
     public Set<String> getRowKeyNamesSet() {
         return rowKeyNamesSet;


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Fix isSamePropertiesNames flag in ObTableTabletOp is wrong


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
