### PR TITLE
[Bugfix] batch get select empty return error

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableLSOpFlag.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableLSOpFlag.java
@@ -21,6 +21,7 @@ public class ObTableLSOpFlag {
     private static final int FLAG_IS_SAME_TYPE             = 1 << 0;
     private static final int FLAG_IS_SAME_PROPERTIES_NAMES = 1 << 1;
     private static final int FLAG_RETURN_ONE_RESULT        = 1 << 2;
+    private static final int FLAG_NEED_ALL_PROP            = 1 << 3;
     private long             flags                         = 0;
 
     public void setFlagIsSameType(boolean isSameType) {
@@ -47,6 +48,14 @@ public class ObTableLSOpFlag {
         }
     }
 
+    public void setFlagNeedAllProp(boolean needAllProp) {
+        if (needAllProp) {
+            flags |= FLAG_NEED_ALL_PROP;
+        } else {
+            flags &= ~FLAG_NEED_ALL_PROP;
+        }
+    }
+
     public long getValue() {
         return flags;
     }
@@ -62,4 +71,6 @@ public class ObTableLSOpFlag {
     public boolean getFlagIsSamePropertiesNames() {
         return (flags & FLAG_IS_SAME_PROPERTIES_NAMES) != 0;
     }
+
+    public boolean getFlagNeedAllProp() { return (flags & FLAG_NEED_ALL_PROP) != 0;}
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableLSOperation.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableLSOperation.java
@@ -245,6 +245,10 @@ public class ObTableLSOperation extends AbstractPayload {
         optionFlag.setFlagIsSamePropertiesNames(isSamePropertiesNames);
     }
 
+    public void setNeedAllProp(boolean needAllProp) { optionFlag.setFlagNeedAllProp(needAllProp);}
+
+    public boolean isNeedAllProp() { return optionFlag.getFlagNeedAllProp(); }
+
     public long getTableId() {
         return tableId;
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -188,9 +188,9 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
         String[] propertiesNames = query.getSelectColumns().toArray(new String[0]);
         ObTableSingleOpEntity entity = ObTableSingleOpEntity.getInstance(rowKeyNames, rowKey,
             propertiesNames, null);
-//        if (propertiesNames.length == 0) {
+        if (propertiesNames.length == 0) {
             needAllProp = true;
-//        }
+        }
         ObTableSingleOp singleOp = new ObTableSingleOp();
         singleOp.setSingleOpType(ObTableOperationType.GET);
         singleOp.addEntity(entity);
@@ -416,6 +416,7 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                 isFirstEntry = false;
             }
         }
+
         // Since we only have one tablet operation
         // We do the LS operation prepare here
        tableLsOp.prepare();

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -50,6 +50,7 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
     private final ObTableClient   obTableClient;
     private ExecutorService       executorService;
     private boolean               returningAffectedEntity = false;
+    private boolean               needAllProp = false;
     private List<ObTableSingleOp> batchOperation;
 
     /*
@@ -187,7 +188,9 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
         String[] propertiesNames = query.getSelectColumns().toArray(new String[0]);
         ObTableSingleOpEntity entity = ObTableSingleOpEntity.getInstance(rowKeyNames, rowKey,
             propertiesNames, null);
-
+//        if (propertiesNames.length == 0) {
+            needAllProp = true;
+//        }
         ObTableSingleOp singleOp = new ObTableSingleOp();
         singleOp.setSingleOpType(ObTableOperationType.GET);
         singleOp.addEntity(entity);
@@ -379,6 +382,7 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
         ObTableLSOperation tableLsOp = new ObTableLSOperation();
         tableLsOp.setLsId(lsId);
         tableLsOp.setReturnOneResult(returnOneResult);
+        tableLsOp.setNeedAllProp(needAllProp);
         tableLsOp.setTableName(tableName);
         // fetch the following parameters in first entry for routing
         long tableId = 0;
@@ -412,7 +416,6 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                 isFirstEntry = false;
             }
         }
-
         // Since we only have one tablet operation
         // We do the LS operation prepare here
        tableLsOp.prepare();

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableClientTest.java
@@ -2517,4 +2517,53 @@ public class ObTableClientTest extends ObTableClientTestBase {
             client.delete(tableName, new Object[] { 0, 2 });
         }
     }
+
+    @Test
+    public void testBatchQuery() throws Exception {
+        String tableName = "test_batch_get";
+        final int COUNT_SIZE = 20;
+        try {
+            int count = COUNT_SIZE;
+            // prepare data
+            for (int i = 0; i < count; i++) {
+                client.insertOrUpdate(tableName).setRowKey(row(colVal("c1", 1), colVal("c2", i)))
+                        .addMutateRow(row(colVal("c3", i + 1), colVal("c4", i + 2))).execute();
+            }
+
+            BatchOperation batchOperation = client.batchOperation(tableName);
+            while (count-- > 0) {
+                Row rowKey = row(colVal("c1", 1), colVal("c2", count));
+                TableQuery query = null;
+                if (count % 2 == 0) {
+                    query = query().setRowKey(rowKey);
+                } else {
+                    query = query().setRowKey(rowKey).select("c2", "c3");
+                }
+                batchOperation.addOperation(query);
+            }
+
+            BatchOperationResult result = batchOperation.execute();
+            int index = COUNT_SIZE;
+            while (index-- > 0) {
+                Row row = result.get(index).getOperationRow();
+                int c2Val = (int) row.get("c2");
+                if (c2Val % 2 == 0) {
+                    assertEquals(4, row.size());
+                    assertEquals(1, row.get("c1"));
+                    assertEquals(c2Val + 1, row.get("c3"));
+                    assertEquals(c2Val + 2, row.get("c4"));
+
+                } else {
+                    assertEquals(2, row.size());
+                    assertEquals(c2Val + 1, row.get("c3"));
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            for (int i=0; i < COUNT_SIZE; i++) {
+                client.delete(tableName).setRowKey(row(colVal("c1", 1), colVal("c2", i))).execute();
+            }
+        }
+    }
 }

--- a/src/test/resources/ci.sql
+++ b/src/test/resources/ci.sql
@@ -507,4 +507,12 @@ CREATE TABLE `test2$family1` (
     PRIMARY KEY (`K`, `Q`, `T`)
 ) TABLEGROUP = test2;
 
+CREATE TABLE `test_batch_get` (
+  `c1` int(11) NOT NULL,
+  `c2` int(11) NOT NULL,
+  `c3` int(11) DEFAULT NULL,
+  `c4` int(11) DEFAULT NULL,
+  PRIMARY KEY (`c1`, `c2`)
+) partition by key(`c2`) partitions 3;
+
 alter system set kv_hotkey_throttle_threshold = 50;


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
when use get operation with empty select columns in batch, it will return indexOutRange exception caused by the name bitmap is not correct.



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
