### PR TITLE
fix: execute result duplicated when do ls batch in odp mode

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -469,12 +469,9 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                 break;
             } catch (Exception ex) {
                 if (obTableClient.isOdpMode()) {
-                    if ((tryTimes - 1) < obTableClient.getRuntimeRetryTimes()) {
-                        logger.warn("batch ops execute while meet Exception, tablename:{}, errorCode: {} , errorMsg: {}, try times {}",
-                                     tableName, ((ObTableException) ex).getErrorCode(), ex.getMessage(), tryTimes);
-                    } else {
-                        throw ex;
-                    }
+                    logger.warn("meet exception when execute ls batch in odp mode." +
+                            "tablename: {}, errMsg: {}", tableName, ex.getMessage());
+                    throw ex;
                 } else if (ex instanceof ObTableReplicaNotReadableException) {
                     if ((tryTimes - 1) < obTableClient.getRuntimeRetryTimes()) {
                         logger.warn("tablename:{} ls id:{} retry when replica not readable: {}",


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
In ODP mode, if a cross-partition request fails partially, the obproxy will return the first error code. The client will catch the exception and retry, causing the original successful requests to be executed repeatedly, thus executing repeatedly.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
