### PR TITLE
fix: relogin invalid when MAX_CONN_EXPIRED_TIME > 2

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableConnection.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableConnection.java
@@ -58,7 +58,7 @@ public class ObTableConnection {
 
     public boolean checkExpired() {
         long maxConnectionTimes = obTable.getConnMaxExpiredTime();
-        return lastConnectionTime.isBefore(LocalDateTime.now().minusSeconds(maxConnectionTimes));
+        return lastConnectionTime.isBefore(LocalDateTime.now().minusMinutes(maxConnectionTimes));
     }
 
     public boolean isExpired() {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

fix: relogin invalid when MAX_CONN_EXPIRED_TIME > 2

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
