### PR TITLE
Restore getOrRefreshTableEntry interface

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1049,6 +1049,19 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
      * @param tableName table name
      * @param refresh is re-fresh
      * @param waitForRefresh wait re-fresh
+     * @return this
+     * @throws Exception if fail
+     */
+    public TableEntry getOrRefreshTableEntry(final String tableName, final boolean refresh,
+                                             final boolean waitForRefresh) throws Exception {
+        return getOrRefreshTableEntry(tableName, refresh, waitForRefresh, false);
+    }
+    
+    /**
+     * Get or refresh table entry.
+     * @param tableName table name
+     * @param refresh is re-fresh
+     * @param waitForRefresh wait re-fresh
      * @param fetchAll fetch all data from server if needed
      * @return this
      * @throws Exception if fail


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Restored the `getOrRefreshTableEntry` interface to support external usage requirements. This change effectively disables the `fetchAll` parameter in the overloaded method, ensuring backward compatibility and proper operation for external dependencies.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
