### PR TITLE
remove unneeded retry codes

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
@@ -209,7 +209,6 @@ public class ObTableRemoting extends BaseRemoting {
                 || errorCode == ResultCodes.OB_PARTITION_IS_BLOCKED.errorCode
                 || errorCode == ResultCodes.OB_SERVER_IS_INIT.errorCode
                 || errorCode == ResultCodes.OB_SERVER_IS_STOPPING.errorCode
-                || errorCode == ResultCodes.OB_TENANT_NOT_IN_SERVER.errorCode
                 || errorCode == ResultCodes.OB_TRANS_RPC_TIMEOUT.errorCode
                 || errorCode == ResultCodes.OB_NO_READABLE_REPLICA.errorCode;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
When a tenant does not exist, directly capturing the error code and retrying will never succeed due to the use of the old tenant ID. In this case, the client needs to re-login for authentication. 

We should no longer retry this error code and instead return it directly to the client.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
