### PR TITLE
fix returnOneResult is not support in ob 421

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObClusterTableBatchOps.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObClusterTableBatchOps.java
@@ -17,6 +17,7 @@
 
 package com.alipay.oceanbase.rpc;
 
+import com.alipay.oceanbase.rpc.exception.FeatureNotSupportedException;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.*;
 import com.alipay.oceanbase.rpc.table.AbstractTableBatchOps;
 import com.alipay.oceanbase.rpc.table.ObTableClientBatchOpsImpl;
@@ -190,7 +191,10 @@ public class ObClusterTableBatchOps extends AbstractTableBatchOps {
             throw new IllegalArgumentException("operations is empty");
         }
         ObTableOperationType lastType = operations.get(0).getOperationType();
-        if (returnOneResult
+        if (returnOneResult && !ObGlobal.isReturnOneResultSupport()) {
+            throw new FeatureNotSupportedException(
+                    "returnOneResult is not supported in this Observer version [" + ObGlobal.obVsnString() +"]");
+        } else if (returnOneResult
             && !(this.tableBatchOps.getObTableBatchOperation().isSameType() && (lastType == ObTableOperationType.INSERT
                                                                                 || lastType == ObTableOperationType.PUT
                                                                                 || lastType == ObTableOperationType.REPLACE || lastType == ObTableOperationType.DEL))) {

--- a/src/main/java/com/alipay/oceanbase/rpc/ObGlobal.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObGlobal.java
@@ -85,11 +85,17 @@ public class ObGlobal {
         return OB_VERSION >= OB_VERSION_4_2_3_0 && OB_VERSION < OB_VERSION_4_3_0_0;
     }
 
+    public static boolean isReturnOneResultSupport() {
+        return OB_VERSION >= OB_VERSION_4_2_3_0 && OB_VERSION < OB_VERSION_4_3_0_0 || OB_VERSION >= OB_VERSION_4_3_4_0;
+    }
+
     public static final long OB_VERSION_4_2_1_0 = calcVersion(4, (short) 2, (byte) 1, (byte) 0);
 
     public static final long OB_VERSION_4_2_3_0 = calcVersion(4, (short) 2, (byte) 3, (byte) 0);
 
     public static final long OB_VERSION_4_3_0_0 = calcVersion(4, (short) 3, (byte) 0, (byte) 0);
+
+    public static final long OB_VERSION_4_3_4_0 = calcVersion(4, (short) 3, (byte) 4, (byte) 0);
 
     public static long       OB_VERSION         = calcVersion(0, (short) 0, (byte) 0, (byte) 0);
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/mutation/BatchOperation.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/mutation/BatchOperation.java
@@ -19,6 +19,7 @@ package com.alipay.oceanbase.rpc.mutation;
 
 import com.alipay.oceanbase.rpc.ObTableClient;
 import com.alipay.oceanbase.rpc.checkandmutate.CheckAndInsUp;
+import com.alipay.oceanbase.rpc.exception.FeatureNotSupportedException;
 import com.alipay.oceanbase.rpc.exception.ObTableException;
 import com.alipay.oceanbase.rpc.mutation.result.BatchOperationResult;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.ObObj;
@@ -157,7 +158,10 @@ public class BatchOperation {
 
     @SuppressWarnings("unchecked")
     public BatchOperationResult execute() throws Exception {
-        if (returnOneResult
+        if (returnOneResult && !ObGlobal.isReturnOneResultSupport()) {
+            throw new FeatureNotSupportedException(
+                    "returnOneResult is not supported in this Observer version [" + ObGlobal.obVsnString() +"]");
+        } else if (returnOneResult
             && !(isSameType && (lastType == ObTableOperationType.INSERT
                                 || lastType == ObTableOperationType.PUT
                                 || lastType == ObTableOperationType.REPLACE || lastType == ObTableOperationType.DEL))) {

--- a/src/test/java/com/alipay/oceanbase/rpc/ObAtomicBatchOperationTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObAtomicBatchOperationTest.java
@@ -27,10 +27,7 @@ import com.alipay.oceanbase.rpc.mutation.result.BatchOperationResult;
 import com.alipay.oceanbase.rpc.mutation.result.MutationResult;
 import com.alipay.oceanbase.rpc.table.api.TableBatchOps;
 import com.alipay.oceanbase.rpc.util.ObTableClientTestUtil;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -212,7 +209,9 @@ public class ObAtomicBatchOperationTest {
     }
 
     @Test
+
     public void testReturnOneRes() {
+        Assume.assumeTrue("Skipping returnOneResult when ob version not support", ObGlobal.isReturnOneResultSupport());
         TableBatchOps batchOps = obTableClient.batch("test_varchar_table");
         // no atomic ReturnOneRes batch operation
         try {
@@ -298,6 +297,7 @@ public class ObAtomicBatchOperationTest {
 
     @Test
     public void testReturnOneResPartition() throws Exception {
+        Assume.assumeTrue("Skiping returnOneResult when ob version not support", ObGlobal.isReturnOneResultSupport());
         BatchOperation batchOperation = obTableClient.batchOperation("test_mutation");
         Object values[][] = { { 1L, "c2_val", "c3_val", 100L }, { 200L, "c2_val", "c3_val", 100L },
                 { 401L, "c2_val", "c3_val", 100L }, { 2000L, "c2_val", "c3_val", 100L },
@@ -328,6 +328,7 @@ public class ObAtomicBatchOperationTest {
 
     @Test
     public void testBatchGet() throws Exception {
+        Assume.assumeTrue("Skipping returnOneResult when ob version not support", ObGlobal.isReturnOneResultSupport());
         try {
             {
                 // insert

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableLsBatchTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableLsBatchTest.java
@@ -25,6 +25,7 @@ import com.alipay.oceanbase.rpc.table.api.TableQuery;
 import com.alipay.oceanbase.rpc.util.ObTableClientTestUtil;
 import com.alipay.oceanbase.rpc.util.TimeUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -309,6 +310,7 @@ public class ObTableLsBatchTest {
 
     @Test
     public void testBatchInsert() throws Exception {
+        Assume.assumeTrue("Skipping returnOneResult when ob version not support", ObGlobal.isReturnOneResultSupport());
         BatchOperation batchOperation = client.batchOperation(TABLE_NAME);
         Object values[][] = { { 1L, "c2_val", "c3_val", 100L }, { 400L, "c2_val", "c3_val", 100L },
                 { 401L, "c2_val", "c3_val", 100L }, { 1000L, "c2_val", "c3_val", 100L },
@@ -396,6 +398,7 @@ public class ObTableLsBatchTest {
 
     @Test
     public void testBatchDel() throws Exception {
+        Assume.assumeTrue("Skipping returnOneResult when ob version not support", ObGlobal.isReturnOneResultSupport());
         Object values[][] = { { 1L, "c2_val", "c3_val", 100L }, { 400L, "c2_val", "c3_val", 100L },
                 { 401L, "c2_val", "c3_val", 100L }, { 1000L, "c2_val", "c3_val", 100L },
                 { 1001L, "c2_val", "c3_val", 100L }, { 1002L, "c2_val", "c3_val", 100L }, };
@@ -496,6 +499,7 @@ public class ObTableLsBatchTest {
 
     @Test
     public void testBatchReplace() throws Exception {
+        Assume.assumeTrue("Skipping returnOneResult when ob version not support", ObGlobal.isReturnOneResultSupport());
         Object values[][] = { { 1L, "c2_val", "c3_val", 100L }, { 400L, "c2_val", "c3_val", 100L },
                 { 401L, "c2_val", "c3_val", 100L }, { 1000L, "c2_val", "c3_val", 100L },
                 { 1001L, "c2_val", "c3_val", 100L }, { 1002L, "c2_val", "c3_val", 100L }, };
@@ -712,6 +716,7 @@ public class ObTableLsBatchTest {
 
     @Test
     public void testPut() throws Exception {
+        Assume.assumeTrue("Skipping returnOneResult when ob version not support", ObGlobal.isReturnOneResultSupport());
         // put operation should set binlog_row_image minimal
         Connection connection = ObTableClientTestUtil.getConnection();
         Statement statement = connection.createStatement();


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Add check when setReturnOneResult is true but observer is nor supported and it will throw Exception

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
