### PR TITLE
fix: Avoid JSON generation when configsMap is empty  

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableConnection.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableConnection.java
@@ -149,7 +149,9 @@ public class ObTableConnection {
         request.setTenantName(obTable.getTenantName());
         request.setUserName(obTable.getUserName());
         request.setDatabaseName(obTable.getDatabase());
-        if (loginWithConfigs) {
+        // When the caller doesn't provide any parameters, configsMap is empty.  
+        // In this case, we don't generate any JSON to avoid creating an empty object.
+        if (loginWithConfigs && !obTable.getConfigs().isEmpty()) {
             JSONObject json = new JSONObject(obTable.getConfigs());
             request.setConfigsStr(json.toJSONString());
             loginWithConfigs = false;


### PR DESCRIPTION

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

- Added logic to check if configsMap is empty when no parameters are provided by the caller.  
- Prevent JSON generation to avoid creating an empty object.  
- Updated comments to clarify the behavior when parameters are missing. 

