### PR TITLE
[Fix] bytes in htable filter string changed after convert byte[] to String

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/ObHTableFilter.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/ObHTableFilter.java
@@ -50,7 +50,7 @@ public class ObHTableFilter extends AbstractPayload {
     private int                 maxVersions           = 1;
     private int                 limitPerRowPerCf      = -1;                            // -1 means unlimited
     private int                 offsetPerRowPerCf     = 0;                             // -1 means unlimited
-    private String              filterString;
+    private ObBytesString       filterString          = null;
 
     /*
      * Encode.
@@ -95,7 +95,7 @@ public class ObHTableFilter extends AbstractPayload {
         System.arraycopy(Serialization.encodeVi32(offsetPerRowPerCf), 0, bytes, idx, len);
         idx += len;
         len = Serialization.getNeedBytes(filterString);
-        System.arraycopy(Serialization.encodeVString(filterString), 0, bytes, idx, len);
+        System.arraycopy(Serialization.encodeBytesString(filterString), 0, bytes, idx, len);
         idx += len;
 
         return bytes;
@@ -120,7 +120,7 @@ public class ObHTableFilter extends AbstractPayload {
         this.maxVersions = Serialization.decodeVi32(buf);
         this.limitPerRowPerCf = Serialization.decodeVi32(buf);
         this.offsetPerRowPerCf = Serialization.decodeVi32(buf);
-        this.filterString = Serialization.decodeVString(buf);
+        this.filterString = Serialization.decodeBytesString(buf);
 
         return this;
     }
@@ -262,14 +262,17 @@ public class ObHTableFilter extends AbstractPayload {
     /*
      * Get filter string.
      */
-    public String getFilterString() {
-        return filterString;
+    public byte[] getFilterString() {
+        return filterString.bytes;
     }
 
     /*
      * Set filter string.
      */
-    public void setFilterString(String filterString) {
-        this.filterString = filterString;
+    public void setFilterString(byte[] filterString) {
+        if (this.filterString == null) {
+            this.filterString = new ObBytesString();
+        }
+        this.filterString.bytes = filterString;
     }
 }

--- a/src/test/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/ObTableQueryPayloadTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/ObTableQueryPayloadTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class ObTableQueryPayloadTest {
@@ -185,7 +186,7 @@ public class ObTableQueryPayloadTest {
         assertEquals(obHTableFilter.getLimitPerRowPerCf(), newObHTableFilter.getLimitPerRowPerCf());
         assertEquals(obHTableFilter.getOffsetPerRowPerCf(),
             newObHTableFilter.getOffsetPerRowPerCf());
-        assertEquals(obHTableFilter.getFilterString(), newObHTableFilter.getFilterString());
+        assertArrayEquals(obHTableFilter.getFilterString(), newObHTableFilter.getFilterString());
         assertEquals(obHTableFilter.getSelectColumnQualifier().size(), newObHTableFilter
             .getSelectColumnQualifier().size());
         assertEquals(new String(obHTableFilter.getSelectColumnQualifier().get(0).bytes),
@@ -204,7 +205,7 @@ public class ObTableQueryPayloadTest {
         obHTableFilter.setMaxVersions(300);
         obHTableFilter.setLimitPerRowPerCf(400);
         obHTableFilter.setOffsetPerRowPerCf(500);
-        obHTableFilter.setFilterString("123");
+        obHTableFilter.setFilterString("123".getBytes());
 
         List<ObBytesString> qs = new ArrayList<ObBytesString>();
         qs.add(new ObBytesString("q1".getBytes()));


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Fix bytes in htable filter string changed after convert byte[] to String

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
use byte[] instead of String to store filter String to ensure the byte is the same as user-passed
