### PR TITLE
feature: Add Retry Support for executeMutation, SyncQuery, and QueryAndMutate Commands and Optimize Partial Refresh Performance

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -3221,7 +3221,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                                     "tablename:{} partition id:{} batch ops refresh table while meet ObTableMasterChangeException, errorCode: {}",
                                     request.getTableName(), request.getPartitionId(), ((ObTableException) ex).getErrorCode(), ex);
 
-                            if (isRetryOnChangeMasterTimes() && tryTimes < maxRetries) {
+                            if (isRetryOnChangeMasterTimes() && tryTimes <= maxRetries) {
                                 logger.warn(
                                         "tablename:{} partition id:{} batch ops retry while meet ObTableMasterChangeException, errorCode: {} , retry times {}",
                                         request.getTableName(), request.getPartitionId(), ((ObTableException) ex).getErrorCode(),

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -677,6 +677,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                                     tryTimes);
                             if (ex instanceof ObTableNeedFetchAllException) {
                                 needFetchAllRouteInfo = true;
+                                getOrRefreshTableEntry(tableName, true, true, true);
                                 // reset failure count while fetch all route info
                                 this.resetExecuteContinuousFailureCount(tableName);
                             }
@@ -1679,7 +1680,9 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         }
 
         long partId = getPartition(tableEntry, row); // partition id in 3.x, origin partId in 4.x, logicId
-
+        if (refresh) {
+            refreshTableLocationByTabletId(tableEntry, tableName, getTabletIdByPartId(tableEntry, partId));
+        }
         return getTableInternal(tableName, tableEntry, partId, waitForRefresh, route);
     }
 

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -786,15 +786,14 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                     obPair = new ObPair<Long, ObTableParam>(0L, new ObTableParam(odpTable));
                 } else {
                     if (null != callback.getRowKey()) {
+                        // in the case of retry, the location always needs to be refreshed here
                         if (tryTimes > 1) {
                             TableEntry entry = getOrRefreshTableEntry(tableName, false, false, false);
                             Long partId = getPartition(entry, callback.getRowKey());
                             refreshTableLocationByTabletId(entry, tableName, getTabletIdByPartId(entry, partId));
                         }
                         // using row key
-                        obPair = getTable(tableName, callback.getRowKey(),
-                            needRefreshTableEntry, tableEntryRefreshIntervalWait,
-                            false, route);
+                        obPair = getTable(tableName, callback.getRowKey(), needRefreshTableEntry, tableEntryRefreshIntervalWait, false, route);
                     } else if (null != callback.getKeyRanges()) {
                         // using scan range
                         obPair = getTable(tableName, new ObTableQuery(),

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -3152,41 +3152,95 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                 request.setTimeout(getOdpTable().getObTableOperationTimeout());
                 return getOdpTable().execute(request);
             } else {
+                int maxRetries = getRuntimeRetryTimes(); // Define the maximum number of retries  
+                int tryTimes = 0;
+                long startExecute = System.currentTimeMillis();
+                boolean needRefreshTableEntry = false;
                 Map<Long, ObTableParam> partIdMapObTable = new HashMap<Long, ObTableParam>();
-                for (ObNewRange rang : tableQuery.getKeyRanges()) {
-                    ObRowKey startKey = rang.getStartKey();
-                    int startKeySize = startKey.getObjs().size();
-                    ObRowKey endKey = rang.getEndKey();
-                    int endKeySize = endKey.getObjs().size();
-                    Object[] start = new Object[startKeySize];
-                    Object[] end = new Object[endKeySize];
-                    for (int i = 0; i < startKeySize; i++) {
-                        start[i] = startKey.getObj(i).getValue();
+                while (true) {
+                    long currentExecute = System.currentTimeMillis();
+                    long costMillis = currentExecute - startExecute;
+                    if (costMillis > getRuntimeMaxWait()) {
+                        logger.error(
+                                "tablename:{} it has tried " + tryTimes
+                                        + " times and it has waited " + costMillis
+                                        + "/ms which exceeds response timeout "
+                                        + getRuntimeMaxWait() + "/ms", request.getTableName());
+                        throw new ObTableTimeoutExcetion("it has tried " + tryTimes
+                                + " times and it has waited " + costMillis
+                                + "/ms which exceeds response timeout "
+                                + getRuntimeMaxWait() + "/ms");
                     }
+                    try {
+                        // Recalculate partIdMapObTable
+                        // Clear the map before recalculating
+                        partIdMapObTable.clear(); 
+                        for (ObNewRange rang : tableQuery.getKeyRanges()) {
+                            ObRowKey startKey = rang.getStartKey();
+                            int startKeySize = startKey.getObjs().size();
+                            ObRowKey endKey = rang.getEndKey();
+                            int endKeySize = endKey.getObjs().size();
+                            Object[] start = new Object[startKeySize];
+                            Object[] end = new Object[endKeySize];
+                            for (int i = 0; i < startKeySize; i++) {
+                                start[i] = startKey.getObj(i).getValue();
+                            }
 
-                    for (int i = 0; i < endKeySize; i++) {
-                        end[i] = endKey.getObj(i).getValue();
-                    }
-                    ObBorderFlag borderFlag = rang.getBorderFlag();
-                    List<ObPair<Long, ObTableParam>> pairList = getTables(request.getTableName(),
-                        tableQuery, start, borderFlag.isInclusiveStart(), end,
-                        borderFlag.isInclusiveEnd(), false, false);
-                    for (ObPair<Long, ObTableParam> pair : pairList) {
-                        partIdMapObTable.put(pair.getLeft(), pair.getRight());
-                    }
-                }
-                if (partIdMapObTable.size() > 1) {
-                    throw new ObTablePartitionConsistentException(
-                        "query and mutate must be a atomic operation");
-                }
+                            for (int i = 0; i < endKeySize; i++) {
+                                end[i] = endKey.getObj(i).getValue();
+                            }
+                            ObBorderFlag borderFlag = rang.getBorderFlag();
+                            List<ObPair<Long, ObTableParam>> pairList = getTables(request.getTableName(),
+                                    tableQuery, start, borderFlag.isInclusiveStart(), end,
+                                    borderFlag.isInclusiveEnd(), needRefreshTableEntry, isTableEntryRefreshIntervalWait());
+                            for (ObPair<Long, ObTableParam> pair : pairList) {
+                                partIdMapObTable.put(pair.getLeft(), pair.getRight());
+                            }
+                        }
 
-                for (Long partId : partIdMapObTable.keySet()) {
-                    ObTableParam tableParam = partIdMapObTable.get(partId);
-                    request.setTableId(tableParam.getTableId());
-                    request.setPartitionId(tableParam.getPartitionId());
-                    request.setTimeout(tableParam.getObTable().getObTableOperationTimeout());
-                    ObTable obTable = tableParam.getObTable();
-                    return executeWithRetry(obTable, request, request.getTableName());
+                        // Check if partIdMapObTable size is greater than 1  
+                        if (partIdMapObTable.size() > 1) {
+                            throw new ObTablePartitionConsistentException(
+                                    "query and mutate must be a atomic operation");
+                        }
+                        // Proceed with the operation
+                        Map.Entry<Long, ObTableParam> entry = partIdMapObTable.entrySet().iterator().next();
+                        ObTableParam tableParam = entry.getValue();
+                        request.setTableId(tableParam.getTableId());
+                        request.setPartitionId(tableParam.getPartitionId());
+                        request.setTimeout(tableParam.getObTable().getObTableOperationTimeout());
+                        ObTable obTable = tableParam.getObTable();
+
+                        // Attempt to execute the operation  
+                        return executeWithRetry(obTable, request, request.getTableName());
+                    } catch (Exception ex) {
+                        tryTimes++;
+                        if (ex instanceof ObTableException && ((ObTableException) ex).isNeedRefreshTableEntry()) {
+                            needRefreshTableEntry = true;
+                            logger.warn(
+                                    "tablename:{} partition id:{} batch ops refresh table while meet ObTableMasterChangeException, errorCode: {}",
+                                    request.getTableName(), request.getPartitionId(), ((ObTableException) ex).getErrorCode(), ex);
+
+                            if (isRetryOnChangeMasterTimes() && tryTimes < maxRetries) {
+                                logger.warn(
+                                        "tablename:{} partition id:{} batch ops retry while meet ObTableMasterChangeException, errorCode: {} , retry times {}",
+                                        request.getTableName(), request.getPartitionId(), ((ObTableException) ex).getErrorCode(),
+                                        tryTimes, ex);
+
+                                if (ex instanceof ObTableNeedFetchAllException) {
+                                    // Refresh table info  
+                                    getOrRefreshTableEntry(request.getTableName(), needRefreshTableEntry, isTableEntryRefreshIntervalWait(), true);
+                                }
+                            } else {
+                                calculateContinuousFailure(request.getTableName(), ex.getMessage());
+                                throw ex;
+                            }
+                        } else {
+                            calculateContinuousFailure(request.getTableName(), ex.getMessage());
+                            // Handle other exceptions or rethrow
+                            throw ex;
+                        }
+                    }
                 }
             }
         }

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -168,21 +168,7 @@ public class LocationUtil {
                                                                                 + "   WHERE C.tenant_name = ? "
                                                                                 + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
 
-    private static final String PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4   = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
-                                                                                + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
-                                                                                + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
-                                                                                + "   B.stop_time as stop_time, A.spare1 as replica_type "
-                                                                                + "   FROM oceanbase.__all_virtual_proxy_schema A "
-                                                                                + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
-                                                                                + "   WHERE A.tablet_id = ? AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
-                                                                                + "LEFT JOIN ("
-                                                                                + "   SELECT D.ls_id, D.tablet_id "
-                                                                                + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
-                                                                                + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
-                                                                                + "   WHERE C.tenant_name = ? "
-                                                                                + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
-
-    private static final String PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4_2 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ "
+    private static final String PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ "
                                                                                 + "    A.tablet_id as tablet_id, "
                                                                                 + "    A.svr_ip as svr_ip, "
                                                                                 + "    A.sql_port as sql_port, "
@@ -805,7 +791,7 @@ public class LocationUtil {
     private static String genLocationSQLByTabletId() {
         String sql = null;
         if (ObGlobal.obVsnMajor() >= 4) {
-            sql = PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4_2;
+            sql = PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4;
         } else {
             throw new FeatureNotSupportedException("not support ob version less than 4");
         }

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -1206,9 +1206,6 @@ public class LocationUtil {
         ObPartitionLocationInfo partitionLocationInfo = partitionEntry.getPartitionInfo(tabletId);
 
         while (rs.next()) {
-            if (partitionLocationInfo.initialized.get()) {
-                continue;
-            }
             ReplicaLocation replica = buildReplicaLocation(rs);
             long partitionId = (ObGlobal.obVsnMajor() >= 4) ? rs.getLong("tablet_id") : rs
                 .getLong("partition_id");

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -56,156 +56,178 @@ import java.util.regex.Pattern;
 
 public class LocationUtil {
 
-    private static final Logger logger                                      = TableClientLoggerFactory
-                                                                                .getLogger(LocationUtil.class);
+    private static final Logger logger                                        = TableClientLoggerFactory
+                                                                                  .getLogger(LocationUtil.class);
     static {
         ParserConfig.getGlobalInstance().setSafeMode(true);
     }
 
-    private static final String OB_VERSION_SQL                              = "SELECT /*+READ_CONSISTENCY(WEAK)*/ OB_VERSION() AS CLUSTER_VERSION;";
+    private static final String OB_VERSION_SQL                                = "SELECT /*+READ_CONSISTENCY(WEAK)*/ OB_VERSION() AS CLUSTER_VERSION;";
 
-    private static final String PROXY_INDEX_INFO_SQL                        = "SELECT /*+READ_CONSISTENCY(WEAK)*/ data_table_id, table_id, index_type FROM oceanbase.__all_virtual_table "
-                                                                              + "where table_name = ?";
+    private static final String PROXY_INDEX_INFO_SQL                          = "SELECT /*+READ_CONSISTENCY(WEAK)*/ data_table_id, table_id, index_type FROM oceanbase.__all_virtual_table "
+                                                                                + "where table_name = ?";
 
-    private static final String PROXY_TABLE_ID_SQL                          = "SELECT /*+READ_CONSISTENCY(WEAK)*/ table_id from oceanbase.__all_virtual_proxy_schema "
-                                                                              + "where tenant_name = ? and database_name = ? and table_name = ? limit 1";
+    private static final String PROXY_TABLE_ID_SQL                            = "SELECT /*+READ_CONSISTENCY(WEAK)*/ table_id from oceanbase.__all_virtual_proxy_schema "
+                                                                                + "where tenant_name = ? and database_name = ? and table_name = ? limit 1";
 
-    private static final String OB_TENANT_EXIST_SQL                         = "SELECT /*+READ_CONSISTENCY(WEAK)*/ tenant_id from __all_tenant where tenant_name = ?;";
-
-    @Deprecated
-    @SuppressWarnings("unused")
-    private static final String PROXY_PLAIN_SCHEMA_SQL_FORMAT               = "SELECT /*+READ_CONSISTENCY(WEAK)*/ partition_id, svr_ip, sql_port, table_id, role, part_num, replica_num, schema_version, spare1 "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema "
-                                                                              + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND partition_id in ({0}) AND sql_port > 0 "
-                                                                              + "ORDER BY role ASC LIMIT ?";
-
-    private static final String PROXY_PART_INFO_SQL                         = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_level, part_num, part_type, part_space, part_expr, "
-                                                                              + "part_range_type, part_interval_bin, interval_start_bin, "
-                                                                              + "sub_part_num, sub_part_type, sub_part_space, "
-                                                                              + "sub_part_range_type, def_sub_part_interval_bin, def_sub_interval_start_bin, sub_part_expr, "
-                                                                              + "part_key_name, part_key_type, part_key_idx, part_key_extra, spare1 "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_partition_info "
-                                                                              + "WHERE table_id = ? group by part_key_name order by part_key_name LIMIT ?;";
-    @Deprecated
-    @SuppressWarnings("unused")
-    private static final String PROXY_TENANT_SCHEMA_SQL                     = "SELECT /*+READ_CONSISTENCY(WEAK)*/ svr_ip, sql_port, table_id, role, part_num, replica_num, spare1 "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema "
-                                                                              + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND sql_port > 0 "
-                                                                              + "ORDER BY partition_id ASC, role ASC LIMIT ?";
-
-    private static final String PROXY_DUMMY_LOCATION_SQL                    = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
-                                                                              + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
-                                                                              + ", A.spare1 as replica_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
-                                                                              + "WHERE tenant_name = ? and database_name=? and table_name = ?";
-
-    private static final String PROXY_LOCATION_SQL                          = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
-                                                                              + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
-                                                                              + ", A.spare1 as replica_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
-                                                                              + "WHERE tenant_name = ? and database_name=? and table_name = ? and partition_id = 0";
-
-    private static final String PROXY_LOCATION_SQL_PARTITION                = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
-                                                                              + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
-                                                                              + ", A.spare1 as replica_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
-                                                                              + "WHERE tenant_name = ? and database_name=? and table_name = ? and partition_id in ({0})";
-
-    private static final String PROXY_FIRST_PARTITION_SQL                   = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_id, part_name, high_bound_val "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_partition "
-                                                                              + "WHERE table_id = ? LIMIT ?;";
-
-    private static final String PROXY_SUB_PARTITION_SQL                     = "SELECT /*+READ_CONSISTENCY(WEAK)*/ sub_part_id, part_name, high_bound_val "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_sub_partition "
-                                                                              + "WHERE table_id = ? LIMIT ?;";
-
-    private static final String PROXY_SERVER_STATUS_INFO                    = "SELECT ss.svr_ip, ss.zone, zs.region, zs.spare4 as idc "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_server_stat ss, oceanbase.__all_virtual_zone_stat zs "
-                                                                              + "WHERE zs.zone = ss.zone ;";
+    private static final String OB_TENANT_EXIST_SQL                           = "SELECT /*+READ_CONSISTENCY(WEAK)*/ tenant_id from __all_tenant where tenant_name = ?;";
 
     @Deprecated
     @SuppressWarnings("unused")
-    private static final String PROXY_PLAIN_SCHEMA_SQL_FORMAT_V4            = "SELECT /*+READ_CONSISTENCY(WEAK)*/ tablet_id, svr_ip, sql_port, table_id, role, part_num, replica_num, schema_version, spare1 "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema "
-                                                                              + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND tablet_id in ({0}) AND sql_port > 0 "
-                                                                              + "ORDER BY role ASC LIMIT ?";
+    private static final String PROXY_PLAIN_SCHEMA_SQL_FORMAT                 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ partition_id, svr_ip, sql_port, table_id, role, part_num, replica_num, schema_version, spare1 "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema "
+                                                                                + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND partition_id in ({0}) AND sql_port > 0 "
+                                                                                + "ORDER BY role ASC LIMIT ?";
 
-    private static final String PROXY_PART_INFO_SQL_V4                      = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_level, part_num, part_type, part_space, part_expr, "
-                                                                              + "part_range_type, sub_part_num, sub_part_type, sub_part_space, sub_part_range_type, sub_part_expr, "
-                                                                              + "part_key_name, part_key_type, part_key_idx, part_key_extra, part_key_collation_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_partition_info "
-                                                                              + "WHERE tenant_name = ? and table_id = ? group by part_key_name order by part_key_name LIMIT ?;";
+    private static final String PROXY_PART_INFO_SQL                           = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_level, part_num, part_type, part_space, part_expr, "
+                                                                                + "part_range_type, part_interval_bin, interval_start_bin, "
+                                                                                + "sub_part_num, sub_part_type, sub_part_space, "
+                                                                                + "sub_part_range_type, def_sub_part_interval_bin, def_sub_interval_start_bin, sub_part_expr, "
+                                                                                + "part_key_name, part_key_type, part_key_idx, part_key_extra, spare1 "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_partition_info "
+                                                                                + "WHERE table_id = ? group by part_key_name order by part_key_name LIMIT ?;";
     @Deprecated
     @SuppressWarnings("unused")
-    private static final String PROXY_TENANT_SCHEMA_SQL_V4                  = "SELECT /*+READ_CONSISTENCY(WEAK)*/ svr_ip, sql_port, table_id, role, part_num, replica_num, spare1 "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema "
-                                                                              + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND sql_port > 0 "
-                                                                              + "ORDER BY tablet_id ASC, role ASC LIMIT ?";
+    private static final String PROXY_TENANT_SCHEMA_SQL                       = "SELECT /*+READ_CONSISTENCY(WEAK)*/ svr_ip, sql_port, table_id, role, part_num, replica_num, spare1 "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema "
+                                                                                + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND sql_port > 0 "
+                                                                                + "ORDER BY partition_id ASC, role ASC LIMIT ?";
 
-    private static final String PROXY_DUMMY_LOCATION_SQL_V4                 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.tablet_id as tablet_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
-                                                                              + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
-                                                                              + ", A.spare1 as replica_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
-                                                                              + "WHERE tenant_name = ? and database_name=? and table_name = ?";
+    private static final String PROXY_DUMMY_LOCATION_SQL                      = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
+                                                                                + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
+                                                                                + ", A.spare1 as replica_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
+                                                                                + "WHERE tenant_name = ? and database_name=? and table_name = ?";
 
-    private static final String PROXY_LOCATION_SQL_V4                       = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.tablet_id as tablet_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
-                                                                              + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
-                                                                              + ", A.spare1 as replica_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
-                                                                              + "WHERE tenant_name = ? and database_name=? and table_name = ? and tablet_id = 0";
+    private static final String PROXY_LOCATION_SQL                            = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
+                                                                                + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
+                                                                                + ", A.spare1 as replica_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
+                                                                                + "WHERE tenant_name = ? and database_name=? and table_name = ? and partition_id = 0";
 
-    private static final String PROXY_LOCATION_SQL_PARTITION_V4             = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
-                                                                              + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
-                                                                              + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
-                                                                              + "   B.stop_time as stop_time, A.spare1 as replica_type "
-                                                                              + "   FROM oceanbase.__all_virtual_proxy_schema A "
-                                                                              + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
-                                                                              + "   WHERE A.tablet_id IN ({0}) AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
-                                                                              + "LEFT JOIN ("
-                                                                              + "   SELECT D.ls_id, D.tablet_id "
-                                                                              + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
-                                                                              + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
-                                                                              + "   WHERE C.tenant_name = ? "
-                                                                              + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
+    private static final String PROXY_LOCATION_SQL_PARTITION                  = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
+                                                                                + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
+                                                                                + ", A.spare1 as replica_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
+                                                                                + "WHERE tenant_name = ? and database_name=? and table_name = ? and partition_id in ({0})";
 
-    private static final String PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
-                                                                              + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
-                                                                              + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
-                                                                              + "   B.stop_time as stop_time, A.spare1 as replica_type "
-                                                                              + "   FROM oceanbase.__all_virtual_proxy_schema A "
-                                                                              + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
-                                                                              + "   WHERE A.tablet_id = ? AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
-                                                                              + "LEFT JOIN ("
-                                                                              + "   SELECT D.ls_id, D.tablet_id "
-                                                                              + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
-                                                                              + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
-                                                                              + "   WHERE C.tenant_name = ? "
-                                                                              + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
+    private static final String PROXY_FIRST_PARTITION_SQL                     = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_id, part_name, high_bound_val "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_partition "
+                                                                                + "WHERE table_id = ? LIMIT ?;";
 
-    private static final String PROXY_FIRST_PARTITION_SQL_V4                = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_id, part_name, tablet_id, high_bound_val, sub_part_num "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_partition "
-                                                                              + "WHERE tenant_name = ? and table_id = ? LIMIT ?;";
+    private static final String PROXY_SUB_PARTITION_SQL                       = "SELECT /*+READ_CONSISTENCY(WEAK)*/ sub_part_id, part_name, high_bound_val "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_sub_partition "
+                                                                                + "WHERE table_id = ? LIMIT ?;";
 
-    private static final String PROXY_SUB_PARTITION_SQL_V4                  = "SELECT /*+READ_CONSISTENCY(WEAK)*/ sub_part_id, part_name, tablet_id, high_bound_val "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_sub_partition "
-                                                                              + "WHERE tenant_name = ? and table_id = ? LIMIT ?;";
+    private static final String PROXY_SERVER_STATUS_INFO                      = "SELECT ss.svr_ip, ss.zone, zs.region, zs.spare4 as idc "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_server_stat ss, oceanbase.__all_virtual_zone_stat zs "
+                                                                                + "WHERE zs.zone = ss.zone ;";
 
-    private static final String PROXY_SERVER_STATUS_INFO_V4                 = "SELECT ss.svr_ip, ss.zone, zs.region, zs.idc as idc "
-                                                                              + "FROM DBA_OB_SERVERS ss, DBA_OB_ZONES zs "
-                                                                              + "WHERE zs.zone = ss.zone ;";
+    @Deprecated
+    @SuppressWarnings("unused")
+    private static final String PROXY_PLAIN_SCHEMA_SQL_FORMAT_V4              = "SELECT /*+READ_CONSISTENCY(WEAK)*/ tablet_id, svr_ip, sql_port, table_id, role, part_num, replica_num, schema_version, spare1 "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema "
+                                                                                + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND tablet_id in ({0}) AND sql_port > 0 "
+                                                                                + "ORDER BY role ASC LIMIT ?";
 
-    private static final String home                                        = System.getProperty(
-                                                                                "user.home",
-                                                                                "/home/admin");
+    private static final String PROXY_PART_INFO_SQL_V4                        = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_level, part_num, part_type, part_space, part_expr, "
+                                                                                + "part_range_type, sub_part_num, sub_part_type, sub_part_space, sub_part_range_type, sub_part_expr, "
+                                                                                + "part_key_name, part_key_type, part_key_idx, part_key_extra, part_key_collation_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_partition_info "
+                                                                                + "WHERE tenant_name = ? and table_id = ? group by part_key_name order by part_key_name LIMIT ?;";
+    @Deprecated
+    @SuppressWarnings("unused")
+    private static final String PROXY_TENANT_SCHEMA_SQL_V4                    = "SELECT /*+READ_CONSISTENCY(WEAK)*/ svr_ip, sql_port, table_id, role, part_num, replica_num, spare1 "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema "
+                                                                                + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND sql_port > 0 "
+                                                                                + "ORDER BY tablet_id ASC, role ASC LIMIT ?";
 
-    private static final String TABLE_GROUP_GET_TABLE_NAME_V4               = "SELECT /*+READ_CONSISTENCY(WEAK)*/ table_name "
-                                                                              + "FROM oceanbase.CDB_OB_TABLEGROUP_TABLES "
-                                                                              + "WHERE tablegroup_name = ? and tenant_id = ? limit 1;";
+    private static final String PROXY_DUMMY_LOCATION_SQL_V4                   = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.tablet_id as tablet_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
+                                                                                + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
+                                                                                + ", A.spare1 as replica_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
+                                                                                + "WHERE tenant_name = ? and database_name=? and table_name = ?";
 
-    private static final int    TEMPLATE_PART_ID                            = -1;
+    private static final String PROXY_LOCATION_SQL_V4                         = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.tablet_id as tablet_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
+                                                                                + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
+                                                                                + ", A.spare1 as replica_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
+                                                                                + "WHERE tenant_name = ? and database_name=? and table_name = ? and tablet_id = 0";
+
+    private static final String PROXY_LOCATION_SQL_PARTITION_V4               = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
+                                                                                + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
+                                                                                + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
+                                                                                + "   B.stop_time as stop_time, A.spare1 as replica_type "
+                                                                                + "   FROM oceanbase.__all_virtual_proxy_schema A "
+                                                                                + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
+                                                                                + "   WHERE A.tablet_id IN ({0}) AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
+                                                                                + "LEFT JOIN ("
+                                                                                + "   SELECT D.ls_id, D.tablet_id "
+                                                                                + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
+                                                                                + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
+                                                                                + "   WHERE C.tenant_name = ? "
+                                                                                + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
+
+    private static final String PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4   = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
+                                                                                + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
+                                                                                + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
+                                                                                + "   B.stop_time as stop_time, A.spare1 as replica_type "
+                                                                                + "   FROM oceanbase.__all_virtual_proxy_schema A "
+                                                                                + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
+                                                                                + "   WHERE A.tablet_id = ? AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
+                                                                                + "LEFT JOIN ("
+                                                                                + "   SELECT D.ls_id, D.tablet_id "
+                                                                                + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
+                                                                                + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
+                                                                                + "   WHERE C.tenant_name = ? "
+                                                                                + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
+
+    private static final String PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4_2 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ "
+                                                                                + "    A.tablet_id as tablet_id, "
+                                                                                + "    A.svr_ip as svr_ip, "
+                                                                                + "    A.sql_port as sql_port, "
+                                                                                + "    A.table_id as table_id, "
+                                                                                + "    A.role as role, "
+                                                                                + "    A.replica_num as replica_num, "
+                                                                                + "    A.part_num as part_num, "
+                                                                                + "    (SELECT B.svr_port FROM oceanbase.__all_server B WHERE A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port) as svr_port, "
+                                                                                + "    (SELECT B.status FROM oceanbase.__all_server B WHERE A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port) as status, "
+                                                                                + "    (SELECT B.stop_time FROM oceanbase.__all_server B WHERE A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port) as stop_time, "
+                                                                                + "    A.spare1 as replica_type, "
+                                                                                + "    (SELECT D.ls_id FROM oceanbase.__all_virtual_tablet_to_ls D WHERE A.tablet_id = D.tablet_id AND D.tenant_id = "
+                                                                                + "        (SELECT C.tenant_id FROM oceanbase.DBA_OB_TENANTS C WHERE C.tenant_name = ?)) as ls_id "
+                                                                                + "FROM "
+                                                                                + "    oceanbase.__all_virtual_proxy_schema A "
+                                                                                + "WHERE "
+                                                                                + "    A.tablet_id = ? "
+                                                                                + "    AND A.tenant_name = ? "
+                                                                                + "    AND A.database_name = ? "
+                                                                                + "    AND A.table_name = ?;";
+
+    private static final String PROXY_FIRST_PARTITION_SQL_V4                  = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_id, part_name, tablet_id, high_bound_val, sub_part_num "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_partition "
+                                                                                + "WHERE tenant_name = ? and table_id = ? LIMIT ?;";
+
+    private static final String PROXY_SUB_PARTITION_SQL_V4                    = "SELECT /*+READ_CONSISTENCY(WEAK)*/ sub_part_id, part_name, tablet_id, high_bound_val "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_sub_partition "
+                                                                                + "WHERE tenant_name = ? and table_id = ? LIMIT ?;";
+
+    private static final String PROXY_SERVER_STATUS_INFO_V4                   = "SELECT ss.svr_ip, ss.zone, zs.region, zs.idc as idc "
+                                                                                + "FROM DBA_OB_SERVERS ss, DBA_OB_ZONES zs "
+                                                                                + "WHERE zs.zone = ss.zone ;";
+
+    private static final String home                                          = System.getProperty(
+                                                                                  "user.home",
+                                                                                  "/home/admin");
+
+    private static final String TABLE_GROUP_GET_TABLE_NAME_V4                 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ table_name "
+                                                                                + "FROM oceanbase.CDB_OB_TABLEGROUP_TABLES "
+                                                                                + "WHERE tablegroup_name = ? and tenant_id = ? limit 1;";
+
+    private static final int    TEMPLATE_PART_ID                              = -1;
 
     // limit the size of get tableEntry location from remote each time
-    private static final int    MAX_TABLET_NUMS_EPOCH                       = 300;
+    private static final int    MAX_TABLET_NUMS_EPOCH                         = 300;
 
     private abstract static class TableEntryRefreshWithPriorityCallback<T> {
         abstract T execute(ObServerAddr obServerAddr) throws ObTableEntryRefreshException;
@@ -735,7 +757,7 @@ public class LocationUtil {
                         }
                     }
                 }
-                
+
                 if (ObGlobal.obVsnMajor() >= 4) {
                     // only set empty partitionEntry
                     ObPartitionEntry partitionEntry = new ObPartitionEntry();
@@ -783,7 +805,7 @@ public class LocationUtil {
     private static String genLocationSQLByTabletId() {
         String sql = null;
         if (ObGlobal.obVsnMajor() >= 4) {
-            sql = PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4;
+            sql = PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4_2;
         } else {
             throw new FeatureNotSupportedException("not support ob version less than 4");
         }
@@ -857,11 +879,11 @@ public class LocationUtil {
         String sql = genLocationSQLByTabletId();
         try {
             ps = connection.prepareStatement(sql);
-            ps.setLong(1, tabletId);
-            ps.setString(2, key.getTenantName());
-            ps.setString(3, key.getDatabaseName());
-            ps.setString(4, key.getTableName());
-            ps.setString(5, key.getTenantName());
+            ps.setString(1, key.getTenantName());
+            ps.setLong(2, tabletId);
+            ps.setString(3, key.getTenantName());
+            ps.setString(4, key.getDatabaseName());
+            ps.setString(5, key.getTableName());
             rs = ps.executeQuery();
             getPartitionLocationFromResultSetByTablet(tableEntry, rs, partitionEntry, tabletId);
         } catch (Exception e) {
@@ -912,8 +934,8 @@ public class LocationUtil {
             } catch (Exception e) {
                 RUNTIME.error(LCD.convert("01-00010"), key, partitionNum, tableEntry, e);
                 throw new ObTablePartitionLocationRefreshException(format(
-                        "fail to get partition location entry from remote entryKey = %s partNum = %d tableEntry =%s "
-                                + "offset =%d epoch =%d", key, partitionNum, tableEntry, i, epoch), e);
+                    "fail to get partition location entry from remote entryKey = %s partNum = %d tableEntry =%s "
+                            + "offset =%d epoch =%d", key, partitionNum, tableEntry, i, epoch), e);
             } finally {
                 try {
                     if (null != rs) {
@@ -1205,46 +1227,50 @@ public class LocationUtil {
 
         ObPartitionLocationInfo partitionLocationInfo = partitionEntry.getPartitionInfo(tabletId);
 
-        partitionLocationInfo.rwLock.writeLock().lock();
-        try {
-            while (rs.next()) {
-                ReplicaLocation replica = buildReplicaLocation(rs);
+        while (rs.next()) {
+            if (partitionLocationInfo.initialized.get()) {
+                continue;
+            }
+            ReplicaLocation replica = buildReplicaLocation(rs);
+            long partitionId = (ObGlobal.obVsnMajor() >= 4) ? rs.getLong("tablet_id") : rs
+                .getLong("partition_id");
+            long lsId = ObGlobal.obVsnMajor() >= 4 ? rs.getLong("ls_id") : INVALID_LS_ID;
+            if (rs.wasNull() && ObGlobal.obVsnMajor() >= 4) {
+                lsId = INVALID_LS_ID; // For non-partitioned table  
+            }
 
-                long partitionId = (ObGlobal.obVsnMajor() >= 4) ? rs.getLong("tablet_id") : rs
-                    .getLong("partition_id");
-                long lsId = ObGlobal.obVsnMajor() >= 4 ? rs.getLong("ls_id") : INVALID_LS_ID;
-                if (rs.wasNull() && ObGlobal.obVsnMajor() >= 4) {
-                    lsId = INVALID_LS_ID; // For non-partitioned table  
-                }
-                partitionLocationInfo.setTabletLsId(lsId);
-
-                if (ObGlobal.obVsnMajor() < 4 && tableEntry.isPartitionTable()
-                    && tableEntry.getPartitionInfo().getSubPartDesc() != null) {
-                    partitionId = ObPartIdCalculator.getPartIdx(partitionId, tableEntry
-                        .getPartitionInfo().getSubPartDesc().getPartNum());
-                }
-
-                if (!replica.isValid()) {
-                    RUNTIME
-                        .warn(format(
-                            "Replica is invalid; continuing. Replica=%s, PartitionId/TabletId=%d, TableId=%d",
-                            replica, partitionId, tableEntry.getTableId()));
-                    continue;
-                }
-                ObPartitionLocation location = partitionLocationInfo.getPartitionLocation();
-                if (location == null) {
-                    location = new ObPartitionLocation();
-                    partitionLocationInfo.updateLocation(location);
-                }
-                location.addReplicaLocation(replica);
-
-                if (partitionLocationInfo.initialized.compareAndSet(false, true)) {
-                    partitionLocationInfo.initializationLatch.countDown();
+            if (ObGlobal.obVsnMajor() < 4 && tableEntry.isPartitionTable()
+                && tableEntry.getPartitionInfo().getSubPartDesc() != null) {
+                partitionId = ObPartIdCalculator.getPartIdx(partitionId, tableEntry
+                    .getPartitionInfo().getSubPartDesc().getPartNum());
+            }
+            if (!replica.isValid()) {
+                RUNTIME
+                    .warn(format(
+                        "Replica is invalid; continuing. Replica=%s, PartitionId/TabletId=%d, TableId=%d",
+                        replica, partitionId, tableEntry.getTableId()));
+                continue;
+            }
+            ObPartitionLocation location = partitionLocationInfo.getPartitionLocation();
+            if (location == null) {
+                partitionLocationInfo.rwLock.writeLock().lock();
+                try {
+                    location = partitionLocationInfo.getPartitionLocation();
+                    if (location == null) {
+                        location = new ObPartitionLocation();
+                        partitionLocationInfo.updateLocation(location, lsId);
+                    }
+                } finally {
+                    partitionLocationInfo.rwLock.writeLock().unlock();
                 }
             }
-        } finally {
-            partitionLocationInfo.rwLock.writeLock().unlock();
+            location.addReplicaLocation(replica);
+
+            if (partitionLocationInfo.initialized.compareAndSet(false, true)) {
+                partitionLocationInfo.initializationLatch.countDown();
+            }
         }
+
         return partitionEntry;
     }
 

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionLocationInfo.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionLocationInfo.java
@@ -40,17 +40,24 @@ public class ObPartitionLocationInfo {
         }
     }
 
-    public void updateLocation(ObPartitionLocation newLocation) {
-        this.partitionLocation = newLocation;
-        this.lastUpdateTime = System.currentTimeMillis();
+    public void updateLocation(ObPartitionLocation newLocation, Long tabletLsId) {
+        rwLock.writeLock().lock();
+        try {
+            this.partitionLocation = newLocation;
+            this.tabletLsId = tabletLsId;
+            this.lastUpdateTime = System.currentTimeMillis();
+        } finally {
+            rwLock.writeLock().unlock();
+        }
     }
 
     public Long getTabletLsId() {
-        return tabletLsId;
-    }
-
-    public void setTabletLsId(Long tabletLsId) {
-        this.tabletLsId = tabletLsId;
+        rwLock.readLock().lock();
+        try {
+            return tabletLsId;
+        } finally {
+            rwLock.readLock().unlock();
+        }
     }
 
     public Long getLastUpdateTime() {

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -45,6 +45,8 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static com.alipay.oceanbase.rpc.util.TableClientLoggerFactory.RUNTIME;
+
 public abstract class AbstractQueryStreamResult extends AbstractPayload implements
                                                                        QueryStreamResult {
 
@@ -61,14 +63,15 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
     // global index: key is index table name (be like: __idx_<data_table_id>_<index_name>)
     protected String                                                           indexTableName;
     protected ObTableEntityType                                                entityType;
-    protected Map<Long, ObPair<Long, ObTableParam>>                            expectant;                                                                                     // Map<logicId, ObPair<logicId, param>>
+    protected Map<Long, ObPair<Long, ObTableParam>>                            expectant;
     protected List<String>                                                     cacheProperties     = new LinkedList<String>();
     protected LinkedList<List<ObObj>>                                          cacheRows           = new LinkedList<List<ObObj>>();
     private LinkedList<ObPair<ObPair<Long, ObTableParam>, ObTableQueryResult>> partitionLastResult = new LinkedList<ObPair<ObPair<Long, ObTableParam>, ObTableQueryResult>>();
     private ObReadConsistency                                                  readConsistency     = ObReadConsistency.STRONG;
     // ObRowKey objs: [startKey, MIN_OBJECT, MIN_OBJECT]
     public List<ObObj>                                                         currentStartKey;
-
+    protected ObTableClient          client;
+    
     /*
      * Get pcode.
      */
@@ -549,9 +552,32 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
             return;
         }
         if (tableQuery.getBatchSize() == -1) {
-            for (Map.Entry<Long, ObPair<Long, ObTableParam>> entry : expectant.entrySet()) {
-                // mark the refer partition
-                referToNewPartition(entry.getValue());
+            if (!expectant.isEmpty()) {
+                Iterator<Map.Entry<Long, ObPair<Long, ObTableParam>>> it = expectant.entrySet()
+                        .iterator();
+                int retryTimes = 0;
+                while (it.hasNext()) {
+                    Map.Entry<Long, ObPair<Long, ObTableParam>> entry = it.next();
+                    try {
+                        // try access new partition, async will not remove useless expectant
+                        referToNewPartition(entry.getValue());
+                    } catch (Exception e) {
+                        if (e instanceof ObTableNeedFetchAllException) {
+                            setExpectant(refreshPartition(tableQuery, tableName));
+                            it = expectant.entrySet().iterator();
+                            retryTimes++;
+                            if (retryTimes > client.getRuntimeRetryTimes()) {
+                                RUNTIME.error("Fail to get refresh table entry response after {}",
+                                        retryTimes);
+                                throw new ObTableRetryExhaustedException(
+                                        "Fail to get refresh table entry response after " + retryTimes);
+
+                            }
+                        } else {
+                            throw e;
+                        }
+                    }
+                }
             }
             expectant.clear();
         } else {
@@ -691,5 +717,20 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
      */
     public void setReadConsistency(ObReadConsistency readConsistency) {
         this.readConsistency = readConsistency;
+    }
+
+    /**
+     * Get client.
+     * @return client
+     */
+    public ObTableClient getClient() {
+        return client;
+    }
+
+    /*
+     * Set client.
+     */
+    public void setClient(ObTableClient client) {
+        this.client = client;
     }
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -620,6 +620,8 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                     client.calculateContinuousFailure(tableName, e.getMessage());
                     throw e;
                 }
+            } else {
+                throw e;
             }
         }
         return iterator; // Return the original iterator if no changes are made  

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -577,6 +577,7 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                 iterator = exceptionHandler.handle(client, maxRetryTimes, tableName, iterator,
                     entry, e, retryTimes);
             }
+            Thread.sleep(client.getRuntimeRetryInterval());
         }
     }
 
@@ -590,7 +591,7 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                                                                                                    throws Exception {
 
         if (client.isOdpMode()) {
-            if ((retryTimes - 1) < maxRetryTimes) {
+            if (retryTimes <= maxRetryTimes) {
                 if (e instanceof ObTableException) {
                     logger.warn(
                         "execute while meet Exception, errorCode: {} , errorMsg: {}, try times {}",

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -568,8 +568,10 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                 if (retryTimes > 1) {
                     TableEntry tableEntry = client.getOrRefreshTableEntry(tableName, false, false,
                         false);
-                    client.refreshTableLocationByTabletId(tableEntry, tableName, entry.getValue()
-                        .getRight().getPartitionId());
+                    if (ObGlobal.obVsnMajor() >= 4 && tableEntry.isPartitionTable()) {
+                        client.refreshTableLocationByTabletId(tableEntry, tableName, entry.getValue()
+                                .getRight().getPartitionId());
+                    }
                 }
                 operation.accept(entry.getValue());
 

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -35,6 +35,7 @@ import com.alipay.oceanbase.rpc.protocol.payload.impl.ObRowKey;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObTableEntityType;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObTableStreamRequest;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.QueryStreamResult;
+import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.syncquery.ObTableQueryAsyncRequest;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.syncquery.ObTableQueryAsyncResult;
 import com.alipay.oceanbase.rpc.stream.ObTableClientQueryStreamResult;
 import com.alipay.oceanbase.rpc.table.ObTable;
@@ -239,7 +240,7 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                     } else if (e instanceof ObTableException) {
                         if ((((ObTableException) e).getErrorCode() == ResultCodes.OB_TABLE_NOT_EXIST.errorCode || ((ObTableException) e)
                             .getErrorCode() == ResultCodes.OB_NOT_SUPPORTED.errorCode)
-                            && ((ObTableQueryRequest) request).getTableQuery().isHbaseQuery()
+                            && ((ObTableQueryAsyncRequest) request).getObTableQueryRequest().getTableQuery().isHbaseQuery()
                             && client.getTableGroupInverted().get(indexTableName) != null) {
                             // table not exists && hbase mode && table group exists , three condition both
                             client.eraseTableGroupFromCache(tableName);

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
@@ -44,7 +44,6 @@ import static com.alipay.oceanbase.rpc.util.TableClientLoggerFactory.RUNTIME;
 public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResult {
     private static final Logger      logger         = LoggerFactory
                                                         .getLogger(ObTableClientQueryStreamResult.class);
-    protected ObTableClient          client;
     private boolean                  isEnd          = true;
     private long                     sessionId      = Constants.OB_INVALID_ID;
     private ObTableQueryAsyncRequest asyncRequest   = new ObTableQueryAsyncRequest();
@@ -338,19 +337,7 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
             closeLastStreamResult(lastEntry.getValue());
         }
     }
-
-    public ObTableClient getClient() {
-        return client;
-    }
-
-    /**
-     * Set client.
-     * @param client client want to set
-     */
-    public void setClient(ObTableClient client) {
-        this.client = client;
-    }
-
+    
     public boolean isEnd() {
         return isEnd;
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryStreamResult.java
@@ -34,10 +34,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ObTableClientQueryStreamResult extends AbstractQueryStreamResult {
-
     private static final Logger logger = TableClientLoggerFactory
                                            .getLogger(ObTableClientQueryStreamResult.class);
-    protected ObTableClient     client;
 
     protected ObTableQueryResult referToNewPartition(ObPair<Long, ObTableParam> partIdWithObTable)
                                                                                                   throws Exception {
@@ -83,20 +81,5 @@ public class ObTableClientQueryStreamResult extends AbstractQueryStreamResult {
                                                                      String tableName)
                                                                                       throws Exception {
         return buildPartitions(client, tableQuery, tableName);
-    }
-
-    /**
-     * Get client.
-     * @return client
-     */
-    public ObTableClient getClient() {
-        return client;
-    }
-
-    /*
-     * Set client.
-     */
-    public void setClient(ObTableClient client) {
-        this.client = client;
     }
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryStreamResult.java
@@ -75,11 +75,4 @@ public class ObTableClientQueryStreamResult extends AbstractQueryStreamResult {
                                                    ObPayload streamRequest) throws Exception {
         throw new IllegalArgumentException("not support this execute");
     }
-
-    @Override
-    protected Map<Long, ObPair<Long, ObTableParam>> refreshPartition(ObTableQuery tableQuery,
-                                                                     String tableName)
-                                                                                      throws Exception {
-        return buildPartitions(client, tableQuery, tableName);
-    }
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -17,6 +17,7 @@
 
 package com.alipay.oceanbase.rpc.table;
 
+import com.alipay.oceanbase.rpc.ObGlobal;
 import com.alipay.oceanbase.rpc.ObTableClient;
 import com.alipay.oceanbase.rpc.exception.*;
 import com.alipay.oceanbase.rpc.location.model.ObServerRoute;
@@ -355,7 +356,9 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
                         }
                         TableEntry entry = obTableClient.getOrRefreshTableEntry(tableName, false,
                             false, false);
-                        obTableClient.refreshTableLocationByTabletId(entry, tableName, partId);
+                        if (ObGlobal.obVsnMajor() >= 4 && entry.isPartitionTable()) {
+                            obTableClient.refreshTableLocationByTabletId(entry, tableName, partId);
+                        }
                         ObTableParam newParam = obTableClient.getTableWithPartId(tableName, partId,
                             false, obTableClient.isTableEntryRefreshIntervalWait(), needFetchAllRouteInfo, route)
                             .getRight();

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -631,7 +631,7 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
         Map<Long, Map<Long, ObPair<ObTableParam, List<ObPair<Integer, ObTableSingleOp>>>>> currentPartitions = new HashMap<>();
         currentPartitions.put(entry.getKey(), entry.getValue());
 
-        while (retryCount < maxRetries && !success) {
+        while (retryCount <= maxRetries && !success) {
             boolean allPartitionsSuccess = true;
 
             for (Map.Entry<Long, Map<Long, ObPair<ObTableParam, List<ObPair<Integer, ObTableSingleOp>>>>> currentEntry : currentPartitions.entrySet()) {

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -17,6 +17,7 @@
 
 package com.alipay.oceanbase.rpc.table;
 
+import com.alipay.oceanbase.rpc.ObGlobal;
 import com.alipay.oceanbase.rpc.ObTableClient;
 import com.alipay.oceanbase.rpc.checkandmutate.CheckAndInsUp;
 import com.alipay.oceanbase.rpc.exception.*;
@@ -476,7 +477,9 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                         }
                         TableEntry entry = obTableClient.getOrRefreshTableEntry(tableName, false,
                                 false, false);
-                        obTableClient.refreshTableLocationByTabletId(entry, tableName, obTableClient.getTabletIdByPartId(entry, originPartId));
+                        if (ObGlobal.obVsnMajor() >= 4 && entry.isPartitionTable()) {
+                            obTableClient.refreshTableLocationByTabletId(entry, tableName, obTableClient.getTabletIdByPartId(entry, originPartId));
+                        }
                         subObTable = obTableClient.getTableWithPartId(tableName, originPartId, needRefreshTableEntry,
                                         obTableClient.isTableEntryRefreshIntervalWait(), false, route).
                                             getRight().getObTable();


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
1. This bugfix introduces a retry mechanism to handle routing errors in executeMutation, SyncQuery, and QueryAndMutate operations. 
2. Optimizes the logic for partial refresh, reducing the degree of thread blocking during startup. As a result, the original performance levels are restored. 


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
By capturing specific error codes, determine when to refresh routing information and update tablet location.
This enhancement ensures that operations can recover from scenarios involving truncation, splitting, and disaster recovery, thereby improving system robustness and reliability.
