### PR TITLE
Fix the issue where the tablet_id is incorrect when the partition tab…

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1654,8 +1654,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         TableEntry tableEntry = getOrRefreshTableEntry(tableName, refresh, waitForRefresh,
             needFetchAll);
         Row row = new Row();
-        if (tableEntry.isPartitionTable()
-            && tableEntry.getPartitionInfo().getLevel() != ObPartitionLevel.LEVEL_ZERO) {
+        if (tableEntry.isPartitionTable()) {
             List<String> curTableRowKeyNames = new ArrayList<String>();
             Map<String, Integer> tableRowKeyEle = getRowKeyElement(tableName);
             if (tableRowKeyEle != null) {
@@ -2048,8 +2047,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         Row startRow = new Row();
         Row endRow = new Row();
         // ensure the format of column names and values if the current table is a table with partition
-        if (tableEntry.isPartitionTable()
-            && tableEntry.getPartitionInfo().getLevel() != ObPartitionLevel.LEVEL_ZERO) {
+        if (tableEntry.isPartitionTable()) {
             // scanRangeColumn may be longer than start/end in prefix scanning situation
             if (scanRangeColumns == null || scanRangeColumns.size() < start.length) {
                 throw new IllegalArgumentException(

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -716,10 +716,10 @@ public class LocationUtil {
             if (null != tableEntry) {
                 tableEntry.setTableEntryKey(key);
                 // TODO: check capacity flag later
+                // fetch partition info
+                fetchPartitionInfo(connection, tableEntry);
                 // fetch tablet ids when table is partition table
                 if (tableEntry.isPartitionTable()) {
-                    // fetch partition info
-                    fetchPartitionInfo(connection, tableEntry);
                     if (null != tableEntry.getPartitionInfo()) {
                         // fetch first range part
                         if (null != tableEntry.getPartitionInfo().getFirstPartDesc()) {

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/TableEntry.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/TableEntry.java
@@ -105,7 +105,9 @@ public class TableEntry {
      * Is partition table.
      */
     public boolean isPartitionTable() {
-        return this.partitionNum > 1;
+        return partitionNum > 1 || (partitionInfo != null && partitionInfo.getLevel()
+                .getIndex() > ObPartitionLevel.LEVEL_ZERO.getIndex() && partitionInfo.getLevel()
+                .getIndex() < ObPartitionLevel.UNKNOWN.getIndex());
     }
 
     /*


### PR DESCRIPTION
…le has a single partition

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Fix the issue where the tablet_id is incorrect when the partition table has a single partition.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
Each time when fetching the tableEntry, retrieve the partition information once. When distinguishing partitioned tables, you can do so based on the number of partitions or the partition information
