### PR TITLE
Fix the issue where the tablet_id is incorrect when the partition table has a single partition

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1654,8 +1654,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         TableEntry tableEntry = getOrRefreshTableEntry(tableName, refresh, waitForRefresh,
             needFetchAll);
         Row row = new Row();
-        if (tableEntry.isPartitionTable()
-            && tableEntry.getPartitionInfo().getLevel() != ObPartitionLevel.LEVEL_ZERO) {
+        if (tableEntry.isPartitionTable()) {
             List<String> curTableRowKeyNames = new ArrayList<String>();
             Map<String, Integer> tableRowKeyEle = getRowKeyElement(tableName);
             if (tableRowKeyEle != null) {
@@ -2048,8 +2047,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         Row startRow = new Row();
         Row endRow = new Row();
         // ensure the format of column names and values if the current table is a table with partition
-        if (tableEntry.isPartitionTable()
-            && tableEntry.getPartitionInfo().getLevel() != ObPartitionLevel.LEVEL_ZERO) {
+        if (tableEntry.isPartitionTable()) {
             // scanRangeColumn may be longer than start/end in prefix scanning situation
             if (scanRangeColumns == null || scanRangeColumns.size() < start.length) {
                 throw new IllegalArgumentException(

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -716,10 +716,10 @@ public class LocationUtil {
             if (null != tableEntry) {
                 tableEntry.setTableEntryKey(key);
                 // TODO: check capacity flag later
+                // fetch partition info
+                fetchPartitionInfo(connection, tableEntry);
                 // fetch tablet ids when table is partition table
                 if (tableEntry.isPartitionTable()) {
-                    // fetch partition info
-                    fetchPartitionInfo(connection, tableEntry);
                     if (null != tableEntry.getPartitionInfo()) {
                         // fetch first range part
                         if (null != tableEntry.getPartitionInfo().getFirstPartDesc()) {

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/TableEntry.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/TableEntry.java
@@ -105,7 +105,9 @@ public class TableEntry {
      * Is partition table.
      */
     public boolean isPartitionTable() {
-        return this.partitionNum > 1;
+        return partitionNum > 1 || (partitionInfo != null && partitionInfo.getLevel()
+                .getIndex() > ObPartitionLevel.LEVEL_ZERO.getIndex() && partitionInfo.getLevel()
+                .getIndex() < ObPartitionLevel.UNKNOWN.getIndex());
     }
 
     /*

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -272,6 +272,13 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
     }
 
     /*
+     * RenewLease.
+     */
+    public void renewLease() throws Exception {
+        throw new IllegalStateException("renew only support stream query");
+    }
+
+    /*
      * Next.
      */
     public boolean next() throws Exception {

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/syncquery/ObQueryOperationType.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/syncquery/ObQueryOperationType.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum ObQueryOperationType {
-    QUERY_START(0), QUERY_NEXT(1), QUERY_END(2);
+    QUERY_START(0), QUERY_NEXT(1), QUERY_END(2), QUERY_RENEW(3);
 
     private int                                       value;
     private static Map<Integer, ObQueryOperationType> map = new HashMap<Integer, ObQueryOperationType>();

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
@@ -181,6 +181,32 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
         return buildPartitions(client, tableQuery, tableName);
     }
 
+    // This function is designed for HBase-type requests.
+    // It is used to extend the session duration of a scan
+    @Override
+    public void renewLease() throws Exception {
+        if (!isEnd() && !expectant.isEmpty()) {
+            Iterator<Map.Entry<Long, ObPair<Long, ObTableParam>>> it = expectant.entrySet()
+                    .iterator();
+            Map.Entry<Long, ObPair<Long, ObTableParam>> lastEntry = it.next();
+            ObPair<Long, ObTableParam> partIdWithObTable = lastEntry.getValue();
+            // try access new partition, async will not remove useless expectant
+            ObTableParam obTableParam = partIdWithObTable.getRight();
+            ObTableQueryRequest queryRequest = asyncRequest.getObTableQueryRequest();
+
+            // refresh request info
+            queryRequest.setPartitionId(obTableParam.getPartitionId());
+            queryRequest.setTableId(obTableParam.getTableId());
+
+            // refresh async query request
+            asyncRequest.setQueryType(ObQueryOperationType.QUERY_RENEW);
+            asyncRequest.setQuerySessionId(sessionId);
+            executeAsync(partIdWithObTable, asyncRequest);
+        } else {
+            throw new ObTableException("query end or expectant is null");
+        }
+    }
+
     @Override
     public boolean next() throws Exception {
         checkStatus();


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Fix the issue where the tablet_id is incorrect when the partition table has a single partition.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
Each time when fetching the tableEntry, retrieve the partition information once. When distinguishing partitioned tables, you can do so based on the number of partitions or the partition information