### PR TITLE
modify version control for direct-load partition

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/direct_load/protocol/v0/ObDirectLoadProtocolV0.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/direct_load/protocol/v0/ObDirectLoadProtocolV0.java
@@ -30,6 +30,8 @@ public class ObDirectLoadProtocolV0 implements ObDirectLoadProtocol {
 
     public static final long         OB_VERSION_4_3_2_0 = ObGlobal.calcVersion(4, (short) 3,
                                                             (byte) 2, (byte) 0);
+    public static final long         OB_VERSION_4_3_5_0 = ObGlobal.calcVersion(4, (short) 3,
+                                                            (byte) 5, (byte) 0);
 
     private static final int         PROTOCOL_VERSION   = 0;
     private final ObDirectLoadLogger logger;
@@ -63,12 +65,14 @@ public class ObDirectLoadProtocolV0 implements ObDirectLoadProtocol {
                             + " is not supported, minimum version required is "
                             + ObGlobal.getObVsnString(OB_VERSION_4_3_2_0));
             }
-        } else if (statement.getPartitionNames().length > 0) {
+        } else if (obVersion < OB_VERSION_4_3_5_0 && statement.getPartitionNames().length > 0) {
             logger.warn("partition names in ob version " + ObGlobal.getObVsnString(obVersion)
-                        + "is not supported");
+                        + "is not supported, minimum version required is "
+                        + ObGlobal.getObVsnString(OB_VERSION_4_3_5_0));
             throw new ObDirectLoadNotSupportedException("partition names in ob version "
-                                                        + ObGlobal.getObVsnString(obVersion)
-                                                        + " is not supported");
+                                                    + ObGlobal.getObVsnString(obVersion)
+                                                    + " is not supported, minimum version required is "
+                                                    + ObGlobal.getObVsnString(OB_VERSION_4_3_5_0));
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Direct-load already supports specified partition level load, but the obkv client has not yet released the check for specified partitions. This PR mainly modified the version check information related to the specified partition


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
modify version control for direct-load partition