### PR TITLE
route single partition refresh

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1382,6 +1382,11 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             }
 
             try {
+                lastRefreshTime = tableEntry.getPartitionEntry().getPartitionInfo(tabletId).getLastUpdateTime();
+                currentTime = System.currentTimeMillis();
+                if (currentTime - lastRefreshTime < tableEntryRefreshLockTimeout) {
+                    return tableEntry;
+                }
                 tableEntry = loadTableEntryLocationWithPriority(serverRoster, tableEntryKey, tableEntry, tabletId,
                         tableEntryAcquireConnectTimeout, tableEntryAcquireSocketTimeout,
                         serverAddressPriorityTimeout, serverAddressCachingTimeout, sysUA);

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -2080,8 +2080,11 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             }
         } else {
             for (Long partId : partIds) {
-                long partitionId = ObPartIdCalculator.getPartIdx(partId, tableEntry
-                        .getPartitionInfo().getSubPartDesc().getPartNum());
+                long partitionId = partId;
+                if (tableEntry.getPartitionInfo().getLevel() == ObPartitionLevel.LEVEL_TWO) {
+                    partitionId = ObPartIdCalculator.getPartIdx(partId, tableEntry
+                            .getPartitionInfo().getSubPartDesc().getPartNum());
+                }
                 replicas.add(new ObPair<Long, ReplicaLocation>(partId, getPartitionLocation(
                         tableEntry, partitionId, route)));
             }

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1366,10 +1366,9 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             if (tableEntry == null) {
                 throw new ObTableEntryRefreshException("Table entry is null, tableName=" + tableName);
             }
-
             long lastRefreshTime = tableEntry.getPartitionEntry().getPartitionInfo(tabletId).getLastUpdateTime();
             long currentTime = System.currentTimeMillis();
-            if (currentTime - lastRefreshTime < tableEntryRefreshIntervalBase) {
+            if (currentTime - lastRefreshTime < tableEntryRefreshLockTimeout) {
                 return tableEntry;
             }
             
@@ -1396,7 +1395,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             RUNTIME.error("RefreshTableEntry encountered an exception", e);
             throw e;
         } catch (Exception e) {
-            String errorMsg = String.format("Failed to get table entry. Key=%s, Original TableEntry=%s, TabletId=%d", tableEntryKey, tableEntry, tabletId);
+            String errorMsg = String.format("Failed to get table entry. Key=%s, TabletId=%d, message=%s", tableEntryKey, tabletId, e.getMessage());
             RUNTIME.error(LCD.convert("01-00020"), tableEntryKey, tableEntry, e);
             throw new ObTableEntryRefreshException(errorMsg, e);
         }

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1396,7 +1396,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             RUNTIME.error("RefreshTableEntry encountered an exception", e);
             throw e;
         } catch (Exception e) {
-            String errorMsg = String.format("Failed to get table entry. Key=%s, Original TableEntry=%s", tableEntryKey, tableEntry);
+            String errorMsg = String.format("Failed to get table entry. Key=%s, Original TableEntry=%s, TabletId=%d", tableEntryKey, tableEntry, tabletId);
             RUNTIME.error(LCD.convert("01-00020"), tableEntryKey, tableEntry, e);
             throw new ObTableEntryRefreshException(errorMsg, e);
         }
@@ -2064,7 +2064,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         }
     }
 
-    private long getTabletIdByPartId(TableEntry tableEntry, Long partId) {
+    public long getTabletIdByPartId(TableEntry tableEntry, Long partId) {
         if (ObGlobal.obVsnMajor() >= 4 && tableEntry.isPartitionTable()) {
             ObPartitionInfo partInfo = tableEntry.getPartitionInfo();
             Map<Long, Long> tabletIdMap = partInfo.getPartTabletIdMap();
@@ -2202,17 +2202,17 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             ObServerAddr addr = replica.getAddr();
             ObTable obTable = tableRoster.get(addr);
             boolean addrExpired = addr.isExpired(serverAddressCachingTimeout);
-//            if (addrExpired || obTable == null) {
-//                logger
-    //                    .warn(
-        //                        "server address {} is expired={} or can not get ob table. So that will sync refresh metadata",
-        //                        addr, addrExpired);
-//                syncRefreshMetadata();
-//                tableEntry = getOrRefreshTableEntry(tableName, true, waitForRefresh, false);
-//                replica = getPartitionLocation(tableEntry, partId, route);
-//                addr = replica.getAddr();
-//                obTable = tableRoster.get(addr);
-//            }
+            if (addrExpired || obTable == null) {
+                logger
+                        .warn(
+                                "server address {} is expired={} or can not get ob table. So that will sync refresh metadata",
+                                addr, addrExpired);
+                syncRefreshMetadata();
+                tableEntry = getOrRefreshTableEntry(tableName, true, waitForRefresh, false);
+                replica = getPartitionLocation(tableEntry, tabletId, route);
+                addr = replica.getAddr();
+                obTable = tableRoster.get(addr);
+            }
 
             if (obTable == null) {
                 RUNTIME.error("cannot get table by addr: " + addr);

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1240,7 +1240,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                     long toHoldTime = punishInterval - interval;
                     logger
                         .info(
-                            "punish table entry {} : table entry refresh time {} punish interval {} current time {}. wait for refresh times {}",
+                            "punish table entry {} : table entry refresh time {} punish interval {} current time {}. wait for refresh times {}ms",
                             tableName, tableEntry.getRefreshTimeMills(), punishInterval, current,
                             toHoldTime);
                     try {
@@ -1438,12 +1438,6 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         
         tableLocations.put(tableName, tableEntry);
         tableEntryRefreshContinuousFailureCount.set(0);
-
-        if (logger.isInfoEnabled()) {
-            logger.info("Refreshed table entry. DataSource: {}, TableName: {}, Key: {}, Entry: {}",
-                    dataSourceName, tableName, tableEntryKey, JSON.toJSON(tableEntry));
-        }
-
         return tableEntry;
     }
 

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -65,6 +65,7 @@ import static com.alipay.oceanbase.rpc.property.Property.*;
 import static com.alipay.oceanbase.rpc.protocol.payload.ResultCodes.OB_ERR_KV_ROUTE_ENTRY_EXPIRE;
 import static com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObTableOperationType.*;
 import static com.alipay.oceanbase.rpc.util.TableClientLoggerFactory.*;
+import static java.lang.String.format;
 
 public class ObTableClient extends AbstractObTableClient implements Lifecycle {
     private static final Logger                               logger                                  = getLogger(ObTableClient.class);
@@ -1942,10 +1943,22 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         long partitionId = partId;
         ObPartitionLocationInfo obPartitionLocationInfo = null;
         if (ObGlobal.obVsnMajor() >= 4) {
-
             obPartitionLocationInfo = getOrRefreshPartitionInfo(tableEntry, tableName, tabletId);
-    
             replica = getPartitionLocation(obPartitionLocationInfo, route);
+            /**
+             * Normally, getOrRefreshPartitionInfo makes sure that a thread only continues if it finds the leader  
+             * during a route refresh. But sometimes, there might not be a leader yet. In this case, the thread  
+             * is released, and since it can't get the replica, it throws an no master exception.  
+             */
+            if (replica == null && obPartitionLocationInfo.getPartitionLocation().getLeader() == null) {
+                RUNTIME.error(LCD.convert("01-00028"), partitionId, tableEntry.getPartitionEntry(), tableEntry);
+                RUNTIME.error(format(
+                        "partition=%d has no leader partitionEntry=%s original tableEntry=%s",
+                        partitionId, tableEntry.getPartitionEntry(), tableEntry));
+                throw new ObTablePartitionNoMasterException(format(
+                        "partition=%d has no leader partitionEntry=%s original tableEntry=%s",
+                        partitionId, tableEntry.getPartitionEntry(), tableEntry));
+            }
         } else {
             if (tableEntry.isPartitionTable()
                     && null != tableEntry.getPartitionInfo().getSubPartDesc()) {

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1664,7 +1664,10 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
      */
     private ReplicaLocation getPartitionLocation(TableEntry tableEntry, long partId,
                                                  ObServerRoute route) {
-        return tableEntry.getPartitionEntry().getPartitionLocationWithPartId(partId)
+        // In all cases for 3.x and for non-partitioned tables in 4.x, partId will not change.
+        // If it is 4.x, it will be converted to tablet id. 
+        partId = getTabletIdByPartId(tableEntry, partId);
+        return tableEntry.getPartitionEntry().getPartitionLocationWithTabletId(partId)
             .getReplica(route);
 
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -2326,12 +2326,8 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
 
             ObTableParam param = new ObTableParam(obTable);
             param.setPartId(partId);
-            if (ObGlobal.obVsnMajor() >= 4) {
-                long partIdx = tableEntry.getPartIdx(partId);
-                partId = tableEntry.isPartitionTable() ? tableEntry.getPartitionInfo()
-                        .getPartTabletIdMap().get(partIdx) : partId;
-                param.setLsId(tableEntry.getPartitionEntry().getLsId(partId));
-            }
+            partId = getTabletIdByPartId(tableEntry, partId);
+            param.setLsId(tableEntry.getPartitionEntry().getPartitionInfo(partId).getTabletLsId());
 
             param.setTableId(tableEntry.getTableId());
             // real partition(tablet) id

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1369,7 +1369,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
 
             long lastRefreshTime = tableEntry.getPartitionEntry().getPartitionInfo(tabletId).getLastUpdateTime();
             long currentTime = System.currentTimeMillis();
-            if (currentTime - lastRefreshTime < 200) {
+            if (currentTime - lastRefreshTime < tableEntryRefreshIntervalBase) {
                 return tableEntry;
             }
             
@@ -2209,7 +2209,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                                 addr, addrExpired);
                 syncRefreshMetadata();
                 tableEntry = getOrRefreshTableEntry(tableName, true, waitForRefresh, false);
-                replica = getPartitionLocation(tableEntry, tabletId, route);
+                replica = getPartitionLocation(tableEntry, partId, route);
                 addr = replica.getAddr();
                 obTable = tableRoster.get(addr);
             }

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1664,8 +1664,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
      */
     private ReplicaLocation getPartitionLocation(TableEntry tableEntry, long partId,
                                                  ObServerRoute route) {
-        long tabletId = getTabletIdByPartId(tableEntry, partId);
-        return tableEntry.getPartitionEntry().getPartitionLocationWithTabletId(tabletId)
+        return tableEntry.getPartitionEntry().getPartitionLocationWithPartId(partId)
             .getReplica(route);
 
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -2305,7 +2305,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         // obTableParams -> List<Pair<logicId, obTableParams>>
         List<ObPair<Long, ObTableParam>> obTableParams = new ArrayList<ObPair<Long, ObTableParam>>();
         for (ObPair<Long, ReplicaLocation> partIdWithReplica : partIdWithReplicaList) {
-            long partId = partIdWithReplica.getLeft();
+            Long partId = partIdWithReplica.getLeft();
             ReplicaLocation replica = partIdWithReplica.getRight();
             ObServerAddr addr = replica.getAddr();
             ObTable obTable = tableRoster.get(addr);
@@ -2317,7 +2317,13 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                                 addr, addrExpired);
                 syncRefreshMetadata();
                 tableEntry = getOrRefreshTableEntry(tableName, true, waitForRefresh, false);
-                replica = getPartitionLocation(tableEntry, partId, route);
+                if (ObGlobal.obVsnMajor() >= 4) {
+                    long tabletId = getTabletIdByPartId(tableEntry, partId);
+                    ObPartitionLocationInfo locationInfo = getOrRefreshPartitionInfo(tableEntry, tableName, tabletId);
+                    replica = getPartitionLocation(locationInfo, route);
+                } else {
+                    replica = getPartitionLocation(tableEntry, partId, route);
+                }
                 addr = replica.getAddr();
                 obTable = tableRoster.get(addr);
             }

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1431,7 +1431,18 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         try {
             // if table entry is exist we just need to refresh table locations
             if (tableEntry != null && !fetchAll) {
-                // do nothing
+                if (ObGlobal.obVsnMajor() >= 4) {
+                    // do nothing
+                } else {
+                    // 3.x still proactively refreshes all locations
+                    tableEntry = loadTableEntryLocationWithPriority(serverRoster, //
+                            tableEntryKey,//
+                            tableEntry,//
+                            tableEntryAcquireConnectTimeout,//
+                            tableEntryAcquireSocketTimeout,//
+                            serverAddressPriorityTimeout, //
+                            serverAddressCachingTimeout, sysUA);
+                }
             } else {
                 // if table entry is not exist we should fetch partition info and table locations
                 tableEntry = loadTableEntryWithPriority(serverRoster, //
@@ -1937,10 +1948,23 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
     public ObPair<Long, ObTableParam> getTableInternal(String tableName, TableEntry tableEntry,
                                                        long partId, boolean waitForRefresh,
                                                        ObServerRoute route) throws Exception {
+        ReplicaLocation replica = null;
         long tabletId = getTabletIdByPartId(tableEntry, partId);
-        ObPartitionLocationInfo obPartitionLocationInfo = getOrRefreshPartitionInfo(tableEntry, tableName, tabletId);
+        ObPartitionLocationInfo obPartitionLocationInfo = null;
+        if (ObGlobal.obVsnMajor() >= 4) {
 
-        ReplicaLocation replica = getPartitionLocation(obPartitionLocationInfo, route);
+            obPartitionLocationInfo = getOrRefreshPartitionInfo(tableEntry, tableName, tabletId);
+    
+            replica = getPartitionLocation(obPartitionLocationInfo, route);
+        } else {
+            ObPair<Long, ReplicaLocation> partitionReplica = getPartitionReplica(tableEntry, partId,
+                    route);
+            replica = partitionReplica.getRight();
+        }
+        if (replica == null) {
+            RUNTIME.error("Cannot get replica by partId: " + partId);
+            throw new ObTableGetException("Cannot get replica by partId: " + partId);
+        }
         ObServerAddr addr = replica.getAddr();
         ObTable obTable = tableRoster.get(addr);
 
@@ -1953,8 +1977,14 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                 logger.info("Server addr {} is expired, refreshing tableEntry.", addr);
             }
             
-            obPartitionLocationInfo = getOrRefreshPartitionInfo(tableEntry, tableName, tabletId);
-            replica = getPartitionLocation(obPartitionLocationInfo, route);
+            if (ObGlobal.obVsnMajor() >= 4) {
+                obPartitionLocationInfo = getOrRefreshPartitionInfo(tableEntry, tableName, tabletId);
+                replica = getPartitionLocation(obPartitionLocationInfo, route);
+            } else {
+                tableEntry = getOrRefreshTableEntry(tableName, true, waitForRefresh, false);
+                replica = getPartitionReplica(tableEntry, partId, route).getRight();
+            }
+            
             addr = replica.getAddr();
             obTable = tableRoster.get(addr);
 
@@ -1963,8 +1993,14 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                 throw new ObTableGetException("Cannot get table by addr: " + addr);
             }
         }
-
-        ObTableParam param = createTableParam(obTable, tableEntry, obPartitionLocationInfo, partId, tabletId);
+        ObTableParam param = null;
+        if (ObGlobal.obVsnMajor() >= 4) {
+            param = createTableParam(obTable, tableEntry, obPartitionLocationInfo, partId, tabletId);
+        } else {
+            param.setPartId(partId);
+            param.setTableId(tableEntry.getTableId());
+            param.setPartitionId(partId);
+        }
         addr.recordAccess();
         return new ObPair<>(tabletId, param);
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
@@ -31,8 +31,6 @@ import com.alipay.remoting.exception.RemotingException;
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 
-import javax.xml.transform.Result;
-
 import static com.alipay.oceanbase.rpc.protocol.packet.ObCompressType.INVALID_COMPRESSOR;
 import static com.alipay.oceanbase.rpc.protocol.packet.ObCompressType.NONE_COMPRESSOR;
 

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
@@ -197,6 +197,7 @@ public class ObTableRemoting extends BaseRemoting {
                || errorCode == ResultCodes.OB_MAPPING_BETWEEN_TABLET_AND_LS_NOT_EXIST.errorCode
                || errorCode == ResultCodes.OB_SNAPSHOT_DISCARDED.errorCode
                || errorCode == ResultCodes.OB_SCHEMA_EAGAIN.errorCode
+                || errorCode == ResultCodes.OB_ERR_WAIT_REMOTE_SCHEMA_REFRESH.errorCode
                || (pcode == Pcodes.OB_TABLE_API_LS_EXECUTE && errorCode == ResultCodes.OB_NOT_MASTER.errorCode);
     }
 

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
@@ -196,6 +196,7 @@ public class ObTableRemoting extends BaseRemoting {
                || errorCode == ResultCodes.OB_LS_NOT_EXIST.errorCode
                || errorCode == ResultCodes.OB_MAPPING_BETWEEN_TABLET_AND_LS_NOT_EXIST.errorCode
                || errorCode == ResultCodes.OB_SNAPSHOT_DISCARDED.errorCode
+               || errorCode == ResultCodes.OB_SCHEMA_EAGAIN.errorCode
                || (pcode == Pcodes.OB_TABLE_API_LS_EXECUTE && errorCode == ResultCodes.OB_NOT_MASTER.errorCode);
     }
 

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
@@ -31,6 +31,8 @@ import com.alipay.remoting.exception.RemotingException;
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
 
+import javax.xml.transform.Result;
+
 import static com.alipay.oceanbase.rpc.protocol.packet.ObCompressType.INVALID_COMPRESSOR;
 import static com.alipay.oceanbase.rpc.protocol.packet.ObCompressType.NONE_COMPRESSOR;
 

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
@@ -165,7 +165,7 @@ public class ObTableRemoting extends BaseRemoting {
             } else {
                 String errMessage = TraceUtil.formatTraceMessage(conn, response,
                     "receive unexpected command code: " + response.getCmdCode().value());
-                throw new ObTableUnexpectedException(errMessage);
+                throw new ObTableUnexpectedException(errMessage, resultCode.getRcode());
             }
 
             payload.decode(buf);

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -1257,8 +1257,17 @@ public class LocationUtil {
             }
             location.addReplicaLocation(replica);
 
-            if (partitionLocationInfo.initialized.compareAndSet(false, true)) {
+            if (location.getLeader() != null && partitionLocationInfo.initialized.compareAndSet(false, true)) {
                 partitionLocationInfo.initializationLatch.countDown();
+            } else if (rs.isLast() && location.getLeader() == null) {
+                partitionLocationInfo.initializationLatch.countDown();
+                RUNTIME.error(LCD.convert("01-00028"), partitionId, partitionEntry, tableEntry);
+                RUNTIME.error(format(
+                        "partition=%d has no leader partitionEntry=%s original tableEntry=%s",
+                        partitionId, partitionEntry, tableEntry));
+                throw new ObTablePartitionNoMasterException(format(
+                        "partition=%d has no leader partitionEntry=%s original tableEntry=%s",
+                        partitionId, partitionEntry, tableEntry));
             }
         }
 
@@ -1311,8 +1320,17 @@ public class LocationUtil {
                 }
                 location.addReplicaLocation(replica);
 
-                if (partitionLocationInfo.initialized.compareAndSet(false, true)) {
+                if (location.getLeader() != null && partitionLocationInfo.initialized.compareAndSet(false, true)) {
                     partitionLocationInfo.initializationLatch.countDown();
+                } else if (rs.isLast() && location.getLeader() == null) {
+                    partitionLocationInfo.initializationLatch.countDown();
+                    RUNTIME.error(LCD.convert("01-00028"), partitionId, partitionEntry, tableEntry);
+                    RUNTIME.error(format(
+                            "partition=%d has no leader partitionEntry=%s original tableEntry=%s",
+                            partitionId, partitionEntry, tableEntry));
+                    throw new ObTablePartitionNoMasterException(format(
+                            "partition=%d has no leader partitionEntry=%s original tableEntry=%s",
+                            partitionId, partitionEntry, tableEntry)); 
                 }
             } else {
                 partitionId = rs.getLong("partition_id");

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -212,7 +212,8 @@ public class LocationUtil {
     private static final int    TEMPLATE_PART_ID                              = -1;
 
     // limit the size of get tableEntry location from remote each time
-    private static final int    MAX_TABLET_NUMS_EPOCH                         = 300;
+    private static final int    MAX_TABLET_NUMS_EPOCH                       = 300;
+    private static final int    TABLE_ENTRY_LOCATION_REFRESH_THRESHOLD      = 100;
 
     private abstract static class TableEntryRefreshWithPriorityCallback<T> {
         abstract T execute(ObServerAddr obServerAddr) throws ObTableEntryRefreshException;
@@ -744,10 +745,14 @@ public class LocationUtil {
                 }
 
                 if (ObGlobal.obVsnMajor() >= 4) {
-                    // only set empty partitionEntry
-                    ObPartitionEntry partitionEntry = new ObPartitionEntry();
-                    tableEntry.setPartitionEntry(partitionEntry);
-                    tableEntry.setRefreshTimeMills(System.currentTimeMillis());
+                    // only set empty partitionEntry 
+                    if (tableEntry.getPartitionNum() <= TABLE_ENTRY_LOCATION_REFRESH_THRESHOLD) {
+                        getTableEntryLocationFromRemote(connection, key, tableEntry);
+                    } else {
+                        ObPartitionEntry partitionEntry = new ObPartitionEntry();
+                        tableEntry.setPartitionEntry(partitionEntry);
+                        tableEntry.setRefreshTimeMills(System.currentTimeMillis());
+                    }
                 } else {
                     // get location info
                     getTableEntryLocationFromRemote(connection, key, tableEntry);
@@ -914,6 +919,7 @@ public class LocationUtil {
                 ps.setString(1, key.getTenantName());
                 ps.setString(2, key.getDatabaseName());
                 ps.setString(3, key.getTableName());
+                ps.setString(4, key.getTenantName());
                 rs = ps.executeQuery();
                 partitionEntry = getPartitionLocationFromResultSet(tableEntry, rs, partitionEntry);
             } catch (Exception e) {
@@ -1278,28 +1284,55 @@ public class LocationUtil {
                 } else {
                     tabletLsIdMap.put(partitionId, INVALID_LS_ID); // non-partitioned table
                 }
+                ObPartitionLocationInfo partitionLocationInfo = partitionEntry
+                        .getPartitionInfo(partitionId);
+                ObPartitionLocation location = partitionLocationInfo.getPartitionLocation();
+                if (location == null) {
+                    partitionLocationInfo.rwLock.writeLock().lock();
+                    try {
+                        location = partitionLocationInfo.getPartitionLocation();
+                        if (location == null) {
+                            location = new ObPartitionLocation();
+                            partitionLocationInfo.updateLocation(location, lsId);
+                        }
+                    } finally {
+                        partitionLocationInfo.rwLock.writeLock().unlock();
+                    }
+                }
+                if (!replica.isValid()) {
+                    RUNTIME
+                            .warn(format(
+                                    "Replica is invalid; continuing. Replica=%s, PartitionId/TabletId=%d, TableId=%d",
+                                    replica, partitionId, tableEntry.getTableId()));
+                    continue;
+                }
+                location.addReplicaLocation(replica);
+
+                if (partitionLocationInfo.initialized.compareAndSet(false, true)) {
+                    partitionLocationInfo.initializationLatch.countDown();
+                }
             } else {
                 partitionId = rs.getLong("partition_id");
                 if (tableEntry.isPartitionTable()
-                    && null != tableEntry.getPartitionInfo().getSubPartDesc()) {
+                        && null != tableEntry.getPartitionInfo().getSubPartDesc()) {
                     partitionId = ObPartIdCalculator.getPartIdx(partitionId, tableEntry
-                        .getPartitionInfo().getSubPartDesc().getPartNum());
+                            .getPartitionInfo().getSubPartDesc().getPartNum());
                 }
-            }
-            if (!replica.isValid()) {
-                RUNTIME
-                    .warn(format(
-                        "replica is invalid, continue, replica=%s, partitionId/tabletId=%d, tableId=%d",
-                        replica, partitionId, tableEntry.getTableId()));
-                continue;
-            }
-            ObPartitionLocation location = partitionLocation.get(partitionId);
+                if (!replica.isValid()) {
+                    RUNTIME
+                            .warn(format(
+                                    "replica is invalid, continue, replica=%s, partitionId/tabletId=%d, tableId=%d",
+                                    replica, partitionId, tableEntry.getTableId()));
+                    continue;
+                }
+                ObPartitionLocation location = partitionLocation.get(partitionId);
 
-            if (location == null) {
-                location = new ObPartitionLocation();
-                partitionLocation.put(partitionId, location);
+                if (location == null) {
+                    location = new ObPartitionLocation();
+                    partitionLocation.put(partitionId, location);
+                }
+                location.addReplicaLocation(replica);
             }
-            location.addReplicaLocation(replica);
         }
 
         if (ObGlobal.obVsnMajor() < 4) {

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -919,7 +919,10 @@ public class LocationUtil {
                 ps.setString(1, key.getTenantName());
                 ps.setString(2, key.getDatabaseName());
                 ps.setString(3, key.getTableName());
-                ps.setString(4, key.getTenantName());
+                if (ObGlobal.obVsnMajor() >= 4) {
+                    // Only for v4.
+                    ps.setString(4, key.getTenantName());
+                }
                 rs = ps.executeQuery();
                 partitionEntry = getPartitionLocationFromResultSet(tableEntry, rs, partitionEntry);
             } catch (Exception e) {

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -746,10 +746,10 @@ public class LocationUtil {
                 }
 
                 if (ObGlobal.obVsnMajor() >= 4) {
-                    // only set empty partitionEntry 
                     if (tableEntry.getPartitionNum() <= TABLE_ENTRY_LOCATION_REFRESH_THRESHOLD) {
                         getTableEntryLocationFromRemote(connection, key, tableEntry);
                     } else {
+                        // only set empty partitionEntry 
                         ObPartitionEntry partitionEntry = new ObPartitionEntry();
                         tableEntry.setPartitionEntry(partitionEntry);
                         tableEntry.setRefreshTimeMills(System.currentTimeMillis());

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -55,156 +55,164 @@ import java.util.regex.Pattern;
 
 public class LocationUtil {
 
-    private static final Logger logger                                      = TableClientLoggerFactory
-                                                                                .getLogger(LocationUtil.class);
+    private static final Logger logger                                        = TableClientLoggerFactory
+                                                                                  .getLogger(LocationUtil.class);
     static {
         ParserConfig.getGlobalInstance().setSafeMode(true);
     }
 
-    private static final String OB_VERSION_SQL                              = "SELECT /*+READ_CONSISTENCY(WEAK)*/ OB_VERSION() AS CLUSTER_VERSION;";
+    private static final String OB_VERSION_SQL                                = "SELECT /*+READ_CONSISTENCY(WEAK)*/ OB_VERSION() AS CLUSTER_VERSION;";
 
-    private static final String PROXY_INDEX_INFO_SQL                        = "SELECT /*+READ_CONSISTENCY(WEAK)*/ data_table_id, table_id, index_type FROM oceanbase.__all_virtual_table "
-                                                                              + "where table_name = ?";
+    private static final String PROXY_INDEX_INFO_SQL                          = "SELECT /*+READ_CONSISTENCY(WEAK)*/ data_table_id, table_id, index_type FROM oceanbase.__all_virtual_table "
+                                                                                + "where table_name = ?";
 
-    private static final String PROXY_TABLE_ID_SQL                          = "SELECT /*+READ_CONSISTENCY(WEAK)*/ table_id from oceanbase.__all_virtual_proxy_schema "
-                                                                              + "where tenant_name = ? and database_name = ? and table_name = ? limit 1";
+    private static final String PROXY_TABLE_ID_SQL                            = "SELECT /*+READ_CONSISTENCY(WEAK)*/ table_id from oceanbase.__all_virtual_proxy_schema "
+                                                                                + "where tenant_name = ? and database_name = ? and table_name = ? limit 1";
 
-    private static final String OB_TENANT_EXIST_SQL                         = "SELECT /*+READ_CONSISTENCY(WEAK)*/ tenant_id from __all_tenant where tenant_name = ?;";
-
-    @Deprecated
-    @SuppressWarnings("unused")
-    private static final String PROXY_PLAIN_SCHEMA_SQL_FORMAT               = "SELECT /*+READ_CONSISTENCY(WEAK)*/ partition_id, svr_ip, sql_port, table_id, role, part_num, replica_num, schema_version, spare1 "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema "
-                                                                              + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND partition_id in ({0}) AND sql_port > 0 "
-                                                                              + "ORDER BY role ASC LIMIT ?";
-
-    private static final String PROXY_PART_INFO_SQL                         = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_level, part_num, part_type, part_space, part_expr, "
-                                                                              + "part_range_type, part_interval_bin, interval_start_bin, "
-                                                                              + "sub_part_num, sub_part_type, sub_part_space, "
-                                                                              + "sub_part_range_type, def_sub_part_interval_bin, def_sub_interval_start_bin, sub_part_expr, "
-                                                                              + "part_key_name, part_key_type, part_key_idx, part_key_extra, spare1 "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_partition_info "
-                                                                              + "WHERE table_id = ? group by part_key_name order by part_key_name LIMIT ?;";
-    @Deprecated
-    @SuppressWarnings("unused")
-    private static final String PROXY_TENANT_SCHEMA_SQL                     = "SELECT /*+READ_CONSISTENCY(WEAK)*/ svr_ip, sql_port, table_id, role, part_num, replica_num, spare1 "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema "
-                                                                              + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND sql_port > 0 "
-                                                                              + "ORDER BY partition_id ASC, role ASC LIMIT ?";
-
-    private static final String PROXY_DUMMY_LOCATION_SQL                    = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
-                                                                              + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
-                                                                              + ", A.spare1 as replica_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
-                                                                              + "WHERE tenant_name = ? and database_name=? and table_name = ?";
-
-    private static final String PROXY_LOCATION_SQL                          = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
-                                                                              + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
-                                                                              + ", A.spare1 as replica_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
-                                                                              + "WHERE tenant_name = ? and database_name=? and table_name = ? and partition_id = 0";
-
-    private static final String PROXY_LOCATION_SQL_PARTITION                = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
-                                                                              + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
-                                                                              + ", A.spare1 as replica_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
-                                                                              + "WHERE tenant_name = ? and database_name=? and table_name = ? and partition_id in ({0})";
-
-    private static final String PROXY_FIRST_PARTITION_SQL                   = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_id, part_name, high_bound_val "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_partition "
-                                                                              + "WHERE table_id = ? LIMIT ?;";
-
-    private static final String PROXY_SUB_PARTITION_SQL                     = "SELECT /*+READ_CONSISTENCY(WEAK)*/ sub_part_id, part_name, high_bound_val "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_sub_partition "
-                                                                              + "WHERE table_id = ? LIMIT ?;";
-
-    private static final String PROXY_SERVER_STATUS_INFO                    = "SELECT ss.svr_ip, ss.zone, zs.region, zs.spare4 as idc "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_server_stat ss, oceanbase.__all_virtual_zone_stat zs "
-                                                                              + "WHERE zs.zone = ss.zone ;";
+    private static final String OB_TENANT_EXIST_SQL                           = "SELECT /*+READ_CONSISTENCY(WEAK)*/ tenant_id from __all_tenant where tenant_name = ?;";
 
     @Deprecated
     @SuppressWarnings("unused")
-    private static final String PROXY_PLAIN_SCHEMA_SQL_FORMAT_V4            = "SELECT /*+READ_CONSISTENCY(WEAK)*/ tablet_id, svr_ip, sql_port, table_id, role, part_num, replica_num, schema_version, spare1 "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema "
-                                                                              + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND tablet_id in ({0}) AND sql_port > 0 "
-                                                                              + "ORDER BY role ASC LIMIT ?";
+    private static final String PROXY_PLAIN_SCHEMA_SQL_FORMAT                 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ partition_id, svr_ip, sql_port, table_id, role, part_num, replica_num, schema_version, spare1 "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema "
+                                                                                + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND partition_id in ({0}) AND sql_port > 0 "
+                                                                                + "ORDER BY role ASC LIMIT ?";
 
-    private static final String PROXY_PART_INFO_SQL_V4                      = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_level, part_num, part_type, part_space, part_expr, "
-                                                                              + "part_range_type, sub_part_num, sub_part_type, sub_part_space, sub_part_range_type, sub_part_expr, "
-                                                                              + "part_key_name, part_key_type, part_key_idx, part_key_extra, part_key_collation_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_partition_info "
-                                                                              + "WHERE tenant_name = ? and table_id = ? group by part_key_name order by part_key_name LIMIT ?;";
+    private static final String PROXY_PART_INFO_SQL                           = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_level, part_num, part_type, part_space, part_expr, "
+                                                                                + "part_range_type, part_interval_bin, interval_start_bin, "
+                                                                                + "sub_part_num, sub_part_type, sub_part_space, "
+                                                                                + "sub_part_range_type, def_sub_part_interval_bin, def_sub_interval_start_bin, sub_part_expr, "
+                                                                                + "part_key_name, part_key_type, part_key_idx, part_key_extra, spare1 "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_partition_info "
+                                                                                + "WHERE table_id = ? group by part_key_name order by part_key_name LIMIT ?;";
     @Deprecated
     @SuppressWarnings("unused")
-    private static final String PROXY_TENANT_SCHEMA_SQL_V4                  = "SELECT /*+READ_CONSISTENCY(WEAK)*/ svr_ip, sql_port, table_id, role, part_num, replica_num, spare1 "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema "
-                                                                              + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND sql_port > 0 "
-                                                                              + "ORDER BY tablet_id ASC, role ASC LIMIT ?";
+    private static final String PROXY_TENANT_SCHEMA_SQL                       = "SELECT /*+READ_CONSISTENCY(WEAK)*/ svr_ip, sql_port, table_id, role, part_num, replica_num, spare1 "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema "
+                                                                                + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND sql_port > 0 "
+                                                                                + "ORDER BY partition_id ASC, role ASC LIMIT ?";
 
-    private static final String PROXY_DUMMY_LOCATION_SQL_V4                 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.tablet_id as tablet_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
-                                                                              + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
-                                                                              + ", A.spare1 as replica_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
-                                                                              + "WHERE tenant_name = ? and database_name=? and table_name = ?";
+    private static final String PROXY_DUMMY_LOCATION_SQL                      = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
+                                                                                + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
+                                                                                + ", A.spare1 as replica_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
+                                                                                + "WHERE tenant_name = ? and database_name=? and table_name = ?";
 
-    private static final String PROXY_LOCATION_SQL_V4                       = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.tablet_id as tablet_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
-                                                                              + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
-                                                                              + ", A.spare1 as replica_type "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
-                                                                              + "WHERE tenant_name = ? and database_name=? and table_name = ? and tablet_id = 0";
+    private static final String PROXY_LOCATION_SQL                            = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
+                                                                                + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
+                                                                                + ", A.spare1 as replica_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
+                                                                                + "WHERE tenant_name = ? and database_name=? and table_name = ? and partition_id = 0";
 
-    private static final String PROXY_LOCATION_SQL_PARTITION_V4             = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
-                                                                              + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
-                                                                              + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
-                                                                              + "   B.stop_time as stop_time, A.spare1 as replica_type "
-                                                                              + "   FROM oceanbase.__all_virtual_proxy_schema A "
-                                                                              + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
-                                                                              + "   WHERE A.tablet_id IN ({0}) AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
-                                                                              + "LEFT JOIN ("
-                                                                              + "   SELECT D.ls_id, D.tablet_id "
-                                                                              + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
-                                                                              + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
-                                                                              + "   WHERE C.tenant_name = ? "
-                                                                              + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
+    private static final String PROXY_LOCATION_SQL_PARTITION                  = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.partition_id as partition_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
+                                                                                + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
+                                                                                + ", A.spare1 as replica_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
+                                                                                + "WHERE tenant_name = ? and database_name=? and table_name = ? and partition_id in ({0})";
 
-    private static final String PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
-                                                                              + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
-                                                                              + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
-                                                                              + "   B.stop_time as stop_time, A.spare1 as replica_type "
-                                                                              + "   FROM oceanbase.__all_virtual_proxy_schema A "
-                                                                              + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
-                                                                              + "   WHERE A.tablet_id = ? AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
-                                                                              + "LEFT JOIN ("
-                                                                              + "   SELECT D.ls_id, D.tablet_id "
-                                                                              + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
-                                                                              + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
-                                                                              + "   WHERE C.tenant_name = ? "
-                                                                              + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
+    private static final String PROXY_FIRST_PARTITION_SQL                     = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_id, part_name, high_bound_val "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_partition "
+                                                                                + "WHERE table_id = ? LIMIT ?;";
 
-    private static final String PROXY_FIRST_PARTITION_SQL_V4                = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_id, part_name, tablet_id, high_bound_val, sub_part_num "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_partition "
-                                                                              + "WHERE tenant_name = ? and table_id = ? LIMIT ?;";
+    private static final String PROXY_SUB_PARTITION_SQL                       = "SELECT /*+READ_CONSISTENCY(WEAK)*/ sub_part_id, part_name, high_bound_val "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_sub_partition "
+                                                                                + "WHERE table_id = ? LIMIT ?;";
 
-    private static final String PROXY_SUB_PARTITION_SQL_V4                  = "SELECT /*+READ_CONSISTENCY(WEAK)*/ sub_part_id, part_name, tablet_id, high_bound_val "
-                                                                              + "FROM oceanbase.__all_virtual_proxy_sub_partition "
-                                                                              + "WHERE tenant_name = ? and table_id = ? LIMIT ?;";
+    private static final String PROXY_SERVER_STATUS_INFO                      = "SELECT ss.svr_ip, ss.zone, zs.region, zs.spare4 as idc "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_server_stat ss, oceanbase.__all_virtual_zone_stat zs "
+                                                                                + "WHERE zs.zone = ss.zone ;";
 
-    private static final String PROXY_SERVER_STATUS_INFO_V4                 = "SELECT ss.svr_ip, ss.zone, zs.region, zs.idc as idc "
-                                                                              + "FROM DBA_OB_SERVERS ss, DBA_OB_ZONES zs "
-                                                                              + "WHERE zs.zone = ss.zone ;";
+    @Deprecated
+    @SuppressWarnings("unused")
+    private static final String PROXY_PLAIN_SCHEMA_SQL_FORMAT_V4              = "SELECT /*+READ_CONSISTENCY(WEAK)*/ tablet_id, svr_ip, sql_port, table_id, role, part_num, replica_num, schema_version, spare1 "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema "
+                                                                                + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND tablet_id in ({0}) AND sql_port > 0 "
+                                                                                + "ORDER BY role ASC LIMIT ?";
 
-    private static final String home                                        = System.getProperty(
-                                                                                "user.home",
-                                                                                "/home/admin");
+    private static final String PROXY_PART_INFO_SQL_V4                        = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_level, part_num, part_type, part_space, part_expr, "
+                                                                                + "part_range_type, sub_part_num, sub_part_type, sub_part_space, sub_part_range_type, sub_part_expr, "
+                                                                                + "part_key_name, part_key_type, part_key_idx, part_key_extra, part_key_collation_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_partition_info "
+                                                                                + "WHERE tenant_name = ? and table_id = ? group by part_key_name order by part_key_name LIMIT ?;";
+    @Deprecated
+    @SuppressWarnings("unused")
+    private static final String PROXY_TENANT_SCHEMA_SQL_V4                    = "SELECT /*+READ_CONSISTENCY(WEAK)*/ svr_ip, sql_port, table_id, role, part_num, replica_num, spare1 "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema "
+                                                                                + "WHERE tenant_name = ? AND database_name = ?  AND table_name = ? AND sql_port > 0 "
+                                                                                + "ORDER BY tablet_id ASC, role ASC LIMIT ?";
 
-    private static final String TABLE_GROUP_GET_TABLE_NAME_V4               = "SELECT /*+READ_CONSISTENCY(WEAK)*/ table_name "
-                                                                              + "FROM oceanbase.CDB_OB_TABLEGROUP_TABLES "
-                                                                              + "WHERE tablegroup_name = ? and tenant_id = ? limit 1;";
+    private static final String PROXY_DUMMY_LOCATION_SQL_V4                   = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.tablet_id as tablet_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
+                                                                                + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
+                                                                                + ", A.spare1 as replica_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
+                                                                                + "WHERE tenant_name = ? and database_name=? and table_name = ?";
 
-    private static final int    TEMPLATE_PART_ID                            = -1;
+    private static final String PROXY_LOCATION_SQL_V4                         = "SELECT /*+READ_CONSISTENCY(WEAK)*/ A.tablet_id as tablet_id, A.svr_ip as svr_ip, A.sql_port as sql_port, "
+                                                                                + "A.table_id as table_id, A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, B.stop_time as stop_time "
+                                                                                + ", A.spare1 as replica_type "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
+                                                                                + "WHERE tenant_name = ? and database_name=? and table_name = ? and tablet_id = 0";
+
+    private static final String PROXY_LOCATION_SQL_PARTITION_V4               = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
+                                                                                + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
+                                                                                + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
+                                                                                + "   B.stop_time as stop_time, A.spare1 as replica_type "
+                                                                                + "   FROM oceanbase.__all_virtual_proxy_schema A "
+                                                                                + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
+                                                                                + "   WHERE A.tablet_id IN ({0}) AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
+                                                                                + "LEFT JOIN ("
+                                                                                + "   SELECT D.ls_id, D.tablet_id "
+                                                                                + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
+                                                                                + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
+                                                                                + "   WHERE C.tenant_name = ? "
+                                                                                + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
+
+    private static final String PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ "
+                                                                                + "    A.tablet_id as tablet_id, "
+                                                                                + "    A.svr_ip as svr_ip, "
+                                                                                + "    A.sql_port as sql_port, "
+                                                                                + "    A.table_id as table_id, "
+                                                                                + "    A.role as role, "
+                                                                                + "    A.replica_num as replica_num, "
+                                                                                + "    A.part_num as part_num, "
+                                                                                + "    (SELECT B.svr_port FROM oceanbase.__all_server B WHERE A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port) as svr_port, "
+                                                                                + "    (SELECT B.status FROM oceanbase.__all_server B WHERE A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port) as status, "
+                                                                                + "    (SELECT B.stop_time FROM oceanbase.__all_server B WHERE A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port) as stop_time, "
+                                                                                + "    A.spare1 as replica_type, "
+                                                                                + "    (SELECT D.ls_id FROM oceanbase.__all_virtual_tablet_to_ls D WHERE A.tablet_id = D.tablet_id AND D.tenant_id = "
+                                                                                + "        (SELECT C.tenant_id FROM oceanbase.DBA_OB_TENANTS C WHERE C.tenant_name = ?)) as ls_id "
+                                                                                + "FROM "
+                                                                                + "    oceanbase.__all_virtual_proxy_schema A "
+                                                                                + "WHERE "
+                                                                                + "    A.tablet_id = ? "
+                                                                                + "    AND A.tenant_name = ? "
+                                                                                + "    AND A.database_name = ? "
+                                                                                + "    AND A.table_name = ?;";
+
+    private static final String PROXY_FIRST_PARTITION_SQL_V4                  = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_id, part_name, tablet_id, high_bound_val, sub_part_num "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_partition "
+                                                                                + "WHERE tenant_name = ? and table_id = ? LIMIT ?;";
+
+    private static final String PROXY_SUB_PARTITION_SQL_V4                    = "SELECT /*+READ_CONSISTENCY(WEAK)*/ sub_part_id, part_name, tablet_id, high_bound_val "
+                                                                                + "FROM oceanbase.__all_virtual_proxy_sub_partition "
+                                                                                + "WHERE tenant_name = ? and table_id = ? LIMIT ?;";
+
+    private static final String PROXY_SERVER_STATUS_INFO_V4                   = "SELECT ss.svr_ip, ss.zone, zs.region, zs.idc as idc "
+                                                                                + "FROM DBA_OB_SERVERS ss, DBA_OB_ZONES zs "
+                                                                                + "WHERE zs.zone = ss.zone ;";
+
+    private static final String home                                          = System.getProperty(
+                                                                                  "user.home",
+                                                                                  "/home/admin");
+
+    private static final String TABLE_GROUP_GET_TABLE_NAME_V4                 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ table_name "
+                                                                                + "FROM oceanbase.CDB_OB_TABLEGROUP_TABLES "
+                                                                                + "WHERE tablegroup_name = ? and tenant_id = ? limit 1;";
+
+    private static final int    TEMPLATE_PART_ID                              = -1;
 
     // limit the size of get tableEntry location from remote each time
-    private static final int    MAX_TABLET_NUMS_EPOCH                       = 300;
+    private static final int    MAX_TABLET_NUMS_EPOCH                         = 300;
 
     private abstract static class TableEntryRefreshWithPriorityCallback<T> {
         abstract T execute(ObServerAddr obServerAddr) throws ObTableEntryRefreshException;
@@ -734,7 +742,7 @@ public class LocationUtil {
                         }
                     }
                 }
-                
+
                 if (ObGlobal.obVsnMajor() >= 4) {
                     // only set empty partitionEntry
                     ObPartitionEntry partitionEntry = new ObPartitionEntry();
@@ -856,11 +864,11 @@ public class LocationUtil {
         String sql = genLocationSQLByTabletId();
         try {
             ps = connection.prepareStatement(sql);
-            ps.setLong(1, tabletId);
-            ps.setString(2, key.getTenantName());
-            ps.setString(3, key.getDatabaseName());
-            ps.setString(4, key.getTableName());
-            ps.setString(5, key.getTenantName());
+            ps.setString(1, key.getTenantName());
+            ps.setLong(2, tabletId);
+            ps.setString(3, key.getTenantName());
+            ps.setString(4, key.getDatabaseName());
+            ps.setString(5, key.getTableName());
             rs = ps.executeQuery();
             getPartitionLocationFromResultSetByTablet(tableEntry, rs, partitionEntry, tabletId);
         } catch (Exception e) {
@@ -911,8 +919,8 @@ public class LocationUtil {
             } catch (Exception e) {
                 RUNTIME.error(LCD.convert("01-00010"), key, partitionNum, tableEntry, e);
                 throw new ObTablePartitionLocationRefreshException(format(
-                        "fail to get partition location entry from remote entryKey = %s partNum = %d tableEntry =%s "
-                                + "offset =%d epoch =%d", key, partitionNum, tableEntry, i, epoch), e);
+                    "fail to get partition location entry from remote entryKey = %s partNum = %d tableEntry =%s "
+                            + "offset =%d epoch =%d", key, partitionNum, tableEntry, i, epoch), e);
             } finally {
                 try {
                     if (null != rs) {
@@ -1204,46 +1212,47 @@ public class LocationUtil {
 
         ObPartitionLocationInfo partitionLocationInfo = partitionEntry.getPartitionInfo(tabletId);
 
-        partitionLocationInfo.rwLock.writeLock().lock();
-        try {
-            while (rs.next()) {
-                ReplicaLocation replica = buildReplicaLocation(rs);
+        while (rs.next()) {
+            ReplicaLocation replica = buildReplicaLocation(rs);
+            long partitionId = (ObGlobal.obVsnMajor() >= 4) ? rs.getLong("tablet_id") : rs
+                .getLong("partition_id");
+            long lsId = ObGlobal.obVsnMajor() >= 4 ? rs.getLong("ls_id") : INVALID_LS_ID;
+            if (rs.wasNull() && ObGlobal.obVsnMajor() >= 4) {
+                lsId = INVALID_LS_ID; // For non-partitioned table  
+            }
 
-                long partitionId = (ObGlobal.obVsnMajor() >= 4) ? rs.getLong("tablet_id") : rs
-                    .getLong("partition_id");
-                long lsId = ObGlobal.obVsnMajor() >= 4 ? rs.getLong("ls_id") : INVALID_LS_ID;
-                if (rs.wasNull() && ObGlobal.obVsnMajor() >= 4) {
-                    lsId = INVALID_LS_ID; // For non-partitioned table  
-                }
-                partitionLocationInfo.setTabletLsId(lsId);
-
-                if (ObGlobal.obVsnMajor() < 4 && tableEntry.isPartitionTable()
-                    && tableEntry.getPartitionInfo().getSubPartDesc() != null) {
-                    partitionId = ObPartIdCalculator.getPartIdx(partitionId, tableEntry
-                        .getPartitionInfo().getSubPartDesc().getPartNum());
-                }
-
-                if (!replica.isValid()) {
-                    RUNTIME
-                        .warn(format(
-                            "Replica is invalid; continuing. Replica=%s, PartitionId/TabletId=%d, TableId=%d",
-                            replica, partitionId, tableEntry.getTableId()));
-                    continue;
-                }
-                ObPartitionLocation location = partitionLocationInfo.getPartitionLocation();
-                if (location == null) {
-                    location = new ObPartitionLocation();
-                    partitionLocationInfo.updateLocation(location);
-                }
-                location.addReplicaLocation(replica);
-
-                if (partitionLocationInfo.initialized.compareAndSet(false, true)) {
-                    partitionLocationInfo.initializationLatch.countDown();
+            if (ObGlobal.obVsnMajor() < 4 && tableEntry.isPartitionTable()
+                && tableEntry.getPartitionInfo().getSubPartDesc() != null) {
+                partitionId = ObPartIdCalculator.getPartIdx(partitionId, tableEntry
+                    .getPartitionInfo().getSubPartDesc().getPartNum());
+            }
+            if (!replica.isValid()) {
+                RUNTIME
+                    .warn(format(
+                        "Replica is invalid; continuing. Replica=%s, PartitionId/TabletId=%d, TableId=%d",
+                        replica, partitionId, tableEntry.getTableId()));
+                continue;
+            }
+            ObPartitionLocation location = partitionLocationInfo.getPartitionLocation();
+            if (location == null) {
+                partitionLocationInfo.rwLock.writeLock().lock();
+                try {
+                    location = partitionLocationInfo.getPartitionLocation();
+                    if (location == null) {
+                        location = new ObPartitionLocation();
+                        partitionLocationInfo.updateLocation(location, lsId);
+                    }
+                } finally {
+                    partitionLocationInfo.rwLock.writeLock().unlock();
                 }
             }
-        } finally {
-            partitionLocationInfo.rwLock.writeLock().unlock();
+            location.addReplicaLocation(replica);
+
+            if (partitionLocationInfo.initialized.compareAndSet(false, true)) {
+                partitionLocationInfo.initializationLatch.countDown();
+            }
         }
+
         return partitionEntry;
     }
 

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -725,9 +725,9 @@ public class LocationUtil {
                 tableEntry.setTableEntryKey(key);
                 // TODO: check capacity flag later
                 // fetch tablet ids when table is partition table
+                // fetch partition info
+                fetchPartitionInfo(connection, tableEntry);
                 if (tableEntry.isPartitionTable()) {
-                    // fetch partition info
-                    fetchPartitionInfo(connection, tableEntry);
                     if (null != tableEntry.getPartitionInfo()) {
                         // fetch first range part
                         if (null != tableEntry.getPartitionInfo().getFirstPartDesc()) {

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -1257,8 +1257,15 @@ public class LocationUtil {
                     location = partitionLocationInfo.getPartitionLocation();
                     if (location == null) {
                         location = new ObPartitionLocation();
-                        partitionLocationInfo.updateLocation(location, lsId);
                     }
+                    partitionLocationInfo.updateLocation(location, lsId);
+                } finally {
+                    partitionLocationInfo.rwLock.writeLock().unlock();
+                }
+            } else {
+                partitionLocationInfo.rwLock.writeLock().lock();
+                try {
+                    partitionLocationInfo.updateLocation(location, lsId);
                 } finally {
                     partitionLocationInfo.rwLock.writeLock().unlock();
                 }

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -153,19 +153,33 @@ public class LocationUtil {
                                                                               + "FROM oceanbase.__all_virtual_proxy_schema A inner join oceanbase.__all_server B on A.svr_ip = B.svr_ip and A.sql_port = B.inner_port "
                                                                               + "WHERE tenant_name = ? and database_name=? and table_name = ? and tablet_id = 0";
 
-    private static final String PROXY_LOCATION_SQL_PARTITION_V4            = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
-                                                                            + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
-                                                                            + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
-                                                                            + "   B.stop_time as stop_time, A.spare1 as replica_type "
-                                                                            + "   FROM oceanbase.__all_virtual_proxy_schema A "
-                                                                            + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
-                                                                            + "   WHERE A.tablet_id IN ({0}) AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
-                                                                            + "LEFT JOIN ("
-                                                                            + "   SELECT D.ls_id, D.tablet_id "
-                                                                            + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
-                                                                            + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
-                                                                            + "   WHERE C.tenant_name = ? "
-                                                                            + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
+    private static final String PROXY_LOCATION_SQL_PARTITION_V4             = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
+                                                                              + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
+                                                                              + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
+                                                                              + "   B.stop_time as stop_time, A.spare1 as replica_type "
+                                                                              + "   FROM oceanbase.__all_virtual_proxy_schema A "
+                                                                              + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
+                                                                              + "   WHERE A.tablet_id IN ({0}) AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
+                                                                              + "LEFT JOIN ("
+                                                                              + "   SELECT D.ls_id, D.tablet_id "
+                                                                              + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
+                                                                              + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
+                                                                              + "   WHERE C.tenant_name = ? "
+                                                                              + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
+
+    private static final String PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4 = "SELECT /*+READ_CONSISTENCY(WEAK)*/ * FROM ( "
+                                                                              + "   SELECT A.tablet_id as tablet__id, A.svr_ip as svr_ip, A.sql_port as sql_port, A.table_id as table_id, "
+                                                                              + "   A.role as role, A.replica_num as replica_num, A.part_num as part_num, B.svr_port as svr_port, B.status as status, "
+                                                                              + "   B.stop_time as stop_time, A.spare1 as replica_type "
+                                                                              + "   FROM oceanbase.__all_virtual_proxy_schema A "
+                                                                              + "   INNER JOIN oceanbase.__all_server B ON A.svr_ip = B.svr_ip AND A.sql_port = B.inner_port "
+                                                                              + "   WHERE A.tablet_id = ? AND A.tenant_name = ? AND A.database_name = ? AND A.table_name = ?) AS left_table "
+                                                                              + "LEFT JOIN ("
+                                                                              + "   SELECT D.ls_id, D.tablet_id "
+                                                                              + "   FROM oceanbase.__all_virtual_tablet_to_ls D "
+                                                                              + "   INNER JOIN oceanbase.DBA_OB_TENANTS C ON D.tenant_id = C.tenant_id "
+                                                                              + "   WHERE C.tenant_name = ? "
+                                                                              + ") AS right_table ON left_table.tablet__id = right_table.tablet_id;";
 
     private static final String PROXY_FIRST_PARTITION_SQL_V4                = "SELECT /*+READ_CONSISTENCY(WEAK)*/ part_id, part_name, tablet_id, high_bound_val, sub_part_num "
                                                                               + "FROM oceanbase.__all_virtual_proxy_partition "
@@ -380,8 +394,7 @@ public class LocationUtil {
                 RUNTIME.error(LCD.convert("01-00007"), url, key, e);
             }
             throw new ObTableEntryRefreshException(format(
-                "fail to refresh table entry from remote url=%s, key=%s, message=%s", url, key,
-                e.getMessage()), e);
+                "fail to refresh table entry from remote url=%s, key=%s", url, key), e);
         } finally {
             try {
                 if (null != connection) {
@@ -458,6 +471,37 @@ public class LocationUtil {
                             TableEntry execute(Connection connection)
                                                                      throws ObTablePartitionLocationRefreshException {
                                 return getTableEntryLocationFromRemote(connection, key, tableEntry);
+                            }
+                        });
+                }
+            });
+    }
+
+    /*
+     * Load table entry location with priority by tablet id.
+     */
+    public static TableEntry loadTableEntryLocationWithPriority(final ServerRoster serverRoster,
+                                                                final TableEntryKey key,
+                                                                final TableEntry tableEntry,
+                                                                final Long tabletId,
+                                                                final long connectTimeout,
+                                                                final long socketTimeout,
+                                                                final long priorityTimeout,
+                                                                final long cachingTimeout,
+                                                                final ObUserAuth sysUA)
+                                                                                       throws ObTableEntryRefreshException {
+
+        return callTableEntryRefreshWithPriority(serverRoster, priorityTimeout, cachingTimeout,
+            new TableEntryRefreshWithPriorityCallback<TableEntry>() {
+                @Override
+                TableEntry execute(ObServerAddr obServerAddr) throws ObTableEntryRefreshException {
+                    return callTableEntryRefresh(obServerAddr, key, connectTimeout, socketTimeout,
+                        sysUA, true, new TableEntryRefreshCallback<TableEntry>() {
+                            @Override
+                            TableEntry execute(Connection connection)
+                                                                     throws ObTablePartitionLocationRefreshException {
+                                return getTableEntryLocationFromRemote(connection, key, tableEntry,
+                                    tabletId);
                             }
                         });
                 }
@@ -670,10 +714,10 @@ public class LocationUtil {
             if (null != tableEntry) {
                 tableEntry.setTableEntryKey(key);
                 // TODO: check capacity flag later
-                // fetch partition info
-                fetchPartitionInfo(connection, tableEntry);
                 // fetch tablet ids when table is partition table
                 if (tableEntry.isPartitionTable()) {
+                    // fetch partition info
+                    fetchPartitionInfo(connection, tableEntry);
                     if (null != tableEntry.getPartitionInfo()) {
                         // fetch first range part
                         if (null != tableEntry.getPartitionInfo().getFirstPartDesc()) {
@@ -690,8 +734,10 @@ public class LocationUtil {
                     }
                 }
 
-                // get location info
-                getTableEntryLocationFromRemote(connection, key, tableEntry);
+                // only set empty partitionEntry
+                ObPartitionEntry partitionEntry = new ObPartitionEntry();
+                tableEntry.setPartitionEntry(partitionEntry);
+                tableEntry.setRefreshTimeMills(System.currentTimeMillis());
 
                 if (!initialized) {
                     if (BOOT.isInfoEnabled()) {
@@ -724,6 +770,16 @@ public class LocationUtil {
             }
         }
         return tableEntry;
+    }
+
+    private static String genLocationSQLByTabletId() {
+        String sql = null;
+        if (ObGlobal.obVsnMajor() >= 4) {
+            sql = PROXY_LOCATION_SQL_PARTITION_BY_TABLETID_V4;
+        } else {
+            throw new FeatureNotSupportedException("not support ob version less than 4");
+        }
+        return sql;
     }
 
     private static String genLocationSQLByOffset(TableEntry tableEntry, int offset, int size) {
@@ -783,6 +839,45 @@ public class LocationUtil {
         return sql;
     }
 
+    public static TableEntry getTableEntryLocationFromRemote(Connection connection,
+                                                             TableEntryKey key,
+                                                             TableEntry tableEntry, Long tabletId)
+                                                                                                  throws ObTablePartitionLocationRefreshException {
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        ObPartitionEntry partitionEntry = tableEntry.getPartitionEntry();
+        String sql = genLocationSQLByTabletId();
+        try {
+            ps = connection.prepareStatement(sql);
+            ps.setLong(1, tabletId);
+            ps.setString(2, key.getTenantName());
+            ps.setString(3, key.getDatabaseName());
+            ps.setString(4, key.getTableName());
+            ps.setString(5, key.getTenantName());
+            rs = ps.executeQuery();
+            getPartitionLocationFromResultSetByTablet(tableEntry, rs, partitionEntry, tabletId);
+        } catch (Exception e) {
+            RUNTIME.error(LCD.convert("01-00010"), key, tableEntry, e);
+            throw new ObTablePartitionLocationRefreshException(format(
+                "fail to get partition location entry from remote entryKey = %s tableEntry =%s ",
+                key, tableEntry), e);
+        } finally {
+            try {
+                if (null != rs) {
+                    rs.close();
+                }
+                if (null != ps) {
+                    ps.close();
+                }
+            } catch (SQLException e) {
+                // ignore
+            }
+        }
+        // 可能不需要了
+        tableEntry.setRefreshTimeMills(System.currentTimeMillis());
+        return tableEntry;
+    }
+
     /*
      * Get table entry location from remote.
      */
@@ -794,37 +889,6 @@ public class LocationUtil {
         PreparedStatement ps = null;
         ResultSet rs = null;
         ObPartitionEntry partitionEntry = new ObPartitionEntry();
-        long partitionNum = tableEntry.getPartitionNum();
-        int epoch = (int) ((partitionNum / MAX_TABLET_NUMS_EPOCH) + 1);
-        for (int i = 0; i < epoch; i++) {
-            try {
-                int offset = i * MAX_TABLET_NUMS_EPOCH;
-                String sql = genLocationSQLByOffset(tableEntry, offset, MAX_TABLET_NUMS_EPOCH);
-                ps = connection.prepareStatement(sql);
-                ps.setString(1, key.getTenantName());
-                ps.setString(2, key.getDatabaseName());
-                ps.setString(3, key.getTableName());
-                ps.setString(4, key.getTenantName());
-                rs = ps.executeQuery();
-                partitionEntry = getPartitionLocationFromResultSet(tableEntry, rs, partitionEntry);
-            } catch (Exception e) {
-                RUNTIME.error(LCD.convert("01-00010"), key, partitionNum, tableEntry, e);
-                throw new ObTablePartitionLocationRefreshException(format(
-                    "fail to get partition location entry from remote entryKey = %s partNum = %d tableEntry =%s "
-                            + "offset =%d epoch =%d", key, partitionNum, tableEntry, i, epoch), e);
-            } finally {
-                try {
-                    if (null != rs) {
-                        rs.close();
-                    }
-                    if (null != ps) {
-                        ps.close();
-                    }
-                } catch (SQLException e) {
-                    // ignore
-                }
-            }
-        } // end for
         tableEntry.setPartitionEntry(partitionEntry);
         tableEntry.setRefreshTimeMills(System.currentTimeMillis());
         return tableEntry;
@@ -1087,6 +1151,62 @@ public class LocationUtil {
         }
 
         return entry;
+    }
+
+    private static ObPartitionEntry getPartitionLocationFromResultSetByTablet(TableEntry tableEntry,
+                                                                              ResultSet rs,
+                                                                              ObPartitionEntry partitionEntry,
+                                                                              long tabletId)
+                                                                                            throws SQLException,
+                                                                                            ObTablePartitionLocationRefreshException {
+        if (partitionEntry == null || tableEntry == null) {
+            throw new IllegalArgumentException("partitionEntry: " + partitionEntry
+                                               + " tableEntry: " + tableEntry);
+        }
+        ObPartitionLocationInfo partitionLocationInfo = partitionEntry.getPartitionInfo(tabletId);
+        try {
+            partitionLocationInfo.rwLock.writeLock().lock();
+            while (rs.next()) {
+                ReplicaLocation replica = buildReplicaLocation(rs);
+                long partitionId;
+                long lsId;
+                if (ObGlobal.obVsnMajor() >= 4) {
+                    partitionId = rs.getLong("tablet_id");
+                    lsId = rs.getLong("ls_id");
+                    if (rs.wasNull()) {
+                        lsId = INVALID_LS_ID; // non-partitioned table
+                    }
+                    partitionLocationInfo.setTabletLsId(lsId);
+                } else {
+                    partitionId = rs.getLong("partition_id");
+                    if (tableEntry.isPartitionTable()
+                        && null != tableEntry.getPartitionInfo().getSubPartDesc()) {
+                        partitionId = ObPartIdCalculator.getPartIdx(partitionId, tableEntry
+                            .getPartitionInfo().getSubPartDesc().getPartNum());
+                    }
+                }
+                if (!replica.isValid()) {
+                    RUNTIME
+                        .warn(format(
+                            "replica is invalid, continue, replica=%s, partitionId/tabletId=%d, tableId=%d",
+                            replica, partitionId, tableEntry.getTableId()));
+                    continue;
+                }
+                ObPartitionLocation location = partitionLocationInfo.getPartitionLocation();
+
+                if (location == null) {
+                    location = new ObPartitionLocation();
+                    partitionLocationInfo.setPartitionLocation(location);
+                }
+                location.addReplicaLocation(replica);
+            }
+        } finally {
+            partitionLocationInfo.rwLock.writeLock().unlock();
+        }
+        // TODO: v3
+        if (ObGlobal.obVsnMajor() < 4) {
+        }
+        return partitionEntry;
     }
 
     private static ObPartitionEntry getPartitionLocationFromResultSet(TableEntry tableEntry,

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -214,7 +214,7 @@ public class LocationUtil {
 
     // limit the size of get tableEntry location from remote each time
     private static final int    MAX_TABLET_NUMS_EPOCH                       = Integer.parseInt(System.getProperty("max.table.num.epoch","300"));
-    private static final int    TABLE_ENTRY_LOCATION_REFRESH_THRESHOLD      = Integer.parseInt(System.getProperty("table.entry.location.refresh.threshold","100"));
+    private static final int    TABLE_ENTRY_LOCATION_REFRESH_THRESHOLD      = Integer.parseInt(System.getProperty("table.entry.location.refresh.threshold","0"));
 
     private abstract static class TableEntryRefreshWithPriorityCallback<T> {
         abstract T execute(ObServerAddr obServerAddr) throws ObTableEntryRefreshException;

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -873,7 +873,6 @@ public class LocationUtil {
                 // ignore
             }
         }
-        // 可能不需要了
         tableEntry.setRefreshTimeMills(System.currentTimeMillis());
         return tableEntry;
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -734,11 +734,16 @@ public class LocationUtil {
                         }
                     }
                 }
-
-                // only set empty partitionEntry
-                ObPartitionEntry partitionEntry = new ObPartitionEntry();
-                tableEntry.setPartitionEntry(partitionEntry);
-                tableEntry.setRefreshTimeMills(System.currentTimeMillis());
+                
+                if (ObGlobal.obVsnMajor() >= 4) {
+                    // only set empty partitionEntry
+                    ObPartitionEntry partitionEntry = new ObPartitionEntry();
+                    tableEntry.setPartitionEntry(partitionEntry);
+                    tableEntry.setRefreshTimeMills(System.currentTimeMillis());
+                } else {
+                    // get location info
+                    getTableEntryLocationFromRemote(connection, key, tableEntry);
+                }
 
                 if (!initialized) {
                     if (BOOT.isInfoEnabled()) {
@@ -773,6 +778,7 @@ public class LocationUtil {
         return tableEntry;
     }
 
+    // Note: This code is applicable only for refreshing locations based on tablet ID in version 4.x
     private static String genLocationSQLByTabletId() {
         String sql = null;
         if (ObGlobal.obVsnMajor() >= 4) {
@@ -889,6 +895,37 @@ public class LocationUtil {
         PreparedStatement ps = null;
         ResultSet rs = null;
         ObPartitionEntry partitionEntry = new ObPartitionEntry();
+        long partitionNum = tableEntry.getPartitionNum();
+        int epoch = (int) ((partitionNum / MAX_TABLET_NUMS_EPOCH) + 1);
+        for (int i = 0; i < epoch; i++) {
+            try {
+                int offset = i * MAX_TABLET_NUMS_EPOCH;
+                // // This code is executed only in version 3.x
+                String sql = genLocationSQLByOffset(tableEntry, offset, MAX_TABLET_NUMS_EPOCH);
+                ps = connection.prepareStatement(sql);
+                ps.setString(1, key.getTenantName());
+                ps.setString(2, key.getDatabaseName());
+                ps.setString(3, key.getTableName());
+                rs = ps.executeQuery();
+                partitionEntry = getPartitionLocationFromResultSet(tableEntry, rs, partitionEntry);
+            } catch (Exception e) {
+                RUNTIME.error(LCD.convert("01-00010"), key, partitionNum, tableEntry, e);
+                throw new ObTablePartitionLocationRefreshException(format(
+                        "fail to get partition location entry from remote entryKey = %s partNum = %d tableEntry =%s "
+                                + "offset =%d epoch =%d", key, partitionNum, tableEntry, i, epoch), e);
+            } finally {
+                try {
+                    if (null != rs) {
+                        rs.close();
+                    }
+                    if (null != ps) {
+                        ps.close();
+                    }
+                } catch (SQLException e) {
+                    // ignore
+                }
+            }
+        } // end for
         tableEntry.setPartitionEntry(partitionEntry);
         tableEntry.setRefreshTimeMills(System.currentTimeMillis());
         return tableEntry;

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -1159,52 +1159,53 @@ public class LocationUtil {
                                                                               long tabletId)
                                                                                             throws SQLException,
                                                                                             ObTablePartitionLocationRefreshException {
+
         if (partitionEntry == null || tableEntry == null) {
             throw new IllegalArgumentException("partitionEntry: " + partitionEntry
                                                + " tableEntry: " + tableEntry);
         }
+
         ObPartitionLocationInfo partitionLocationInfo = partitionEntry.getPartitionInfo(tabletId);
+
+        partitionLocationInfo.rwLock.writeLock().lock();
         try {
-            partitionLocationInfo.rwLock.writeLock().lock();
             while (rs.next()) {
                 ReplicaLocation replica = buildReplicaLocation(rs);
-                long partitionId;
-                long lsId;
-                if (ObGlobal.obVsnMajor() >= 4) {
-                    partitionId = rs.getLong("tablet_id");
-                    lsId = rs.getLong("ls_id");
-                    if (rs.wasNull()) {
-                        lsId = INVALID_LS_ID; // non-partitioned table
-                    }
-                    partitionLocationInfo.setTabletLsId(lsId);
-                } else {
-                    partitionId = rs.getLong("partition_id");
-                    if (tableEntry.isPartitionTable()
-                        && null != tableEntry.getPartitionInfo().getSubPartDesc()) {
-                        partitionId = ObPartIdCalculator.getPartIdx(partitionId, tableEntry
-                            .getPartitionInfo().getSubPartDesc().getPartNum());
-                    }
+
+                long partitionId = (ObGlobal.obVsnMajor() >= 4) ? rs.getLong("tablet_id") : rs
+                    .getLong("partition_id");
+                long lsId = ObGlobal.obVsnMajor() >= 4 ? rs.getLong("ls_id") : INVALID_LS_ID;
+                if (rs.wasNull() && ObGlobal.obVsnMajor() >= 4) {
+                    lsId = INVALID_LS_ID; // For non-partitioned table  
                 }
+                partitionLocationInfo.setTabletLsId(lsId);
+
+                if (ObGlobal.obVsnMajor() < 4 && tableEntry.isPartitionTable()
+                    && tableEntry.getPartitionInfo().getSubPartDesc() != null) {
+                    partitionId = ObPartIdCalculator.getPartIdx(partitionId, tableEntry
+                        .getPartitionInfo().getSubPartDesc().getPartNum());
+                }
+
                 if (!replica.isValid()) {
                     RUNTIME
                         .warn(format(
-                            "replica is invalid, continue, replica=%s, partitionId/tabletId=%d, tableId=%d",
+                            "Replica is invalid; continuing. Replica=%s, PartitionId/TabletId=%d, TableId=%d",
                             replica, partitionId, tableEntry.getTableId()));
                     continue;
                 }
                 ObPartitionLocation location = partitionLocationInfo.getPartitionLocation();
-
                 if (location == null) {
                     location = new ObPartitionLocation();
-                    partitionLocationInfo.setPartitionLocation(location);
+                    partitionLocationInfo.updateLocation(location);
                 }
                 location.addReplicaLocation(replica);
+
+                if (partitionLocationInfo.initialized.compareAndSet(false, true)) {
+                    partitionLocationInfo.initializationLatch.countDown();
+                }
             }
         } finally {
             partitionLocationInfo.rwLock.writeLock().unlock();
-        }
-        // TODO: v3
-        if (ObGlobal.obVsnMajor() < 4) {
         }
         return partitionEntry;
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -394,7 +394,8 @@ public class LocationUtil {
                 RUNTIME.error(LCD.convert("01-00007"), url, key, e);
             }
             throw new ObTableEntryRefreshException(format(
-                "fail to refresh table entry from remote url=%s, key=%s", url, key), e);
+                "fail to refresh table entry from remote url=%s, key=%s, message=%s", url, key,
+                e.getMessage()), e);
         } finally {
             try {
                 if (null != connection) {

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -212,8 +212,8 @@ public class LocationUtil {
     private static final int    TEMPLATE_PART_ID                              = -1;
 
     // limit the size of get tableEntry location from remote each time
-    private static final int    MAX_TABLET_NUMS_EPOCH                       = 300;
-    private static final int    TABLE_ENTRY_LOCATION_REFRESH_THRESHOLD      = 100;
+    private static final int    MAX_TABLET_NUMS_EPOCH                       = Integer.parseInt(System.getProperty("max.table.num.epoch","300"));
+    private static final int    TABLE_ENTRY_LOCATION_REFRESH_THRESHOLD      = Integer.parseInt(System.getProperty("table.entry.location.refresh.threshold","100"));
 
     private abstract static class TableEntryRefreshWithPriorityCallback<T> {
         abstract T execute(ObServerAddr obServerAddr) throws ObTableEntryRefreshException;

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/TableEntry.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/TableEntry.java
@@ -56,6 +56,26 @@ public class TableEntry {
     private TableEntryKey                    tableEntryKey         = null;
     private volatile ObPartitionEntry        partitionEntry        = null;
     
+    // tablet id ==> refresh time
+    private final ConcurrentHashMap<Long, Long> refreshTimeMap = new ConcurrentHashMap<>();
+    public ConcurrentHashMap<Long, Lock> refreshLockMap = new ConcurrentHashMap<>();
+    
+    public long getTabletLocationLastRefreshTimeMills(Long tabletId) {
+        return refreshTimeMap.getOrDefault(tabletId, 0L);
+    }
+    public void setTableLocationLastRefreshTimeMills(Long tabletId, Long lastRefreshTime) {
+        refreshTimeMap.put(tabletId, lastRefreshTime);
+    }
+    
+    public Lock getRefreshLock(Long tabletId) {
+        return refreshLockMap.get(tabletId);
+    }
+    public void setRefreshLock(Long tabletId, Lock refreshLock) {
+        refreshLockMap.put(tabletId, refreshLock);
+    }
+    
+    
+    
     public ConcurrentHashMap<Long, Lock> refreshLockMap = new ConcurrentHashMap<>();
     
     /*

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/TableEntry.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/TableEntry.java
@@ -56,26 +56,6 @@ public class TableEntry {
     private TableEntryKey                    tableEntryKey         = null;
     private volatile ObPartitionEntry        partitionEntry        = null;
     
-    // tablet id ==> refresh time
-    private final ConcurrentHashMap<Long, Long> refreshTimeMap = new ConcurrentHashMap<>();
-    public ConcurrentHashMap<Long, Lock> refreshLockMap = new ConcurrentHashMap<>();
-    
-    public long getTabletLocationLastRefreshTimeMills(Long tabletId) {
-        return refreshTimeMap.getOrDefault(tabletId, 0L);
-    }
-    public void setTableLocationLastRefreshTimeMills(Long tabletId, Long lastRefreshTime) {
-        refreshTimeMap.put(tabletId, lastRefreshTime);
-    }
-    
-    public Lock getRefreshLock(Long tabletId) {
-        return refreshLockMap.get(tabletId);
-    }
-    public void setRefreshLock(Long tabletId, Lock refreshLock) {
-        refreshLockMap.put(tabletId, refreshLock);
-    }
-    
-    
-    
     public ConcurrentHashMap<Long, Lock> refreshLockMap = new ConcurrentHashMap<>();
     
     /*

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionEntry.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionEntry.java
@@ -31,6 +31,9 @@ public class ObPartitionEntry {
     private Map<Long, Long> tabletLsIdMap = new HashMap<>();
     
     // tabelt id -> (PartitionLocation, LsId)
+    // tablet id 作为索引管理PartitionInfo 其中包含了 PartitionLocation 和LSID
+    // 外部会通过tablet id并发的读写ObPartitionLocationInfo
+    // 写的场景就是更新，读的场景是正常的请求执行，需要保证读写的安全性，更新的时候一方面是保证线程安全，另一方面还需要保证不能频繁更新
     private ConcurrentHashMap<Long, ObPartitionLocationInfo> partitionInfos = new ConcurrentHashMap<>();
 
 

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionEntry.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionEntry.java
@@ -67,18 +67,18 @@ public class ObPartitionEntry {
     }
 
     /*
+     * Get partition location with tablet id.
+     */
+    public ObPartitionLocation getPartitionLocationWithTabletId(long tabletId) {
+        return partitionLocation.get(tabletId);
+    }
+
+    /*
      * Put partition location with part id.
      */
     public ObPartitionLocation putPartitionLocationWithPartId(long partId,
                                                               ObPartitionLocation ObpartitionLocation) {
         return partitionLocation.put(partId, ObpartitionLocation);
-    }
-
-    /*
-     * Get partition location with tablet id.
-     */
-    public ObPartitionLocation getPartitionLocationWithTabletId(long tabletId) {
-        return partitionLocation.get(tabletId);
     }
 
     /*

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionEntry.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionEntry.java
@@ -31,9 +31,6 @@ public class ObPartitionEntry {
     private Map<Long, Long> tabletLsIdMap = new HashMap<>();
     
     // tabelt id -> (PartitionLocation, LsId)
-    // tablet id 作为索引管理PartitionInfo 其中包含了 PartitionLocation 和LSID
-    // 外部会通过tablet id并发的读写ObPartitionLocationInfo
-    // 写的场景就是更新，读的场景是正常的请求执行，需要保证读写的安全性，更新的时候一方面是保证线程安全，另一方面还需要保证不能频繁更新
     private ConcurrentHashMap<Long, ObPartitionLocationInfo> partitionInfos = new ConcurrentHashMap<>();
 
 

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionLocationInfo.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionLocationInfo.java
@@ -19,6 +19,7 @@ package com.alipay.oceanbase.rpc.location.model.partition;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.alipay.oceanbase.rpc.protocol.payload.Constants.OB_INVALID_ID;
@@ -31,7 +32,8 @@ public class ObPartitionLocationInfo {
     public AtomicBoolean          initialized         = new AtomicBoolean(false);
     public final CountDownLatch   initializationLatch = new CountDownLatch(1);
     
-
+    public ReentrantLock refreshLock = new ReentrantLock();
+    
     public ObPartitionLocation getPartitionLocation() {
         rwLock.readLock().lock();
         try {

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionLocationInfo.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionLocationInfo.java
@@ -23,6 +23,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.alipay.oceanbase.rpc.protocol.payload.Constants.OB_INVALID_ID;
 
+// 这个类不做线程安全之类的处理
 public class ObPartitionLocationInfo {
     private ObPartitionLocation   partitionLocation   = null;
     private Long                  tabletLsId          = OB_INVALID_ID;
@@ -30,6 +31,10 @@ public class ObPartitionLocationInfo {
     public ReentrantReadWriteLock rwLock              = new ReentrantReadWriteLock();
     public AtomicBoolean          initialized         = new AtomicBoolean(false);
     public final CountDownLatch   initializationLatch = new CountDownLatch(1);
+
+    public ObPartitionLocationInfo() {
+        this.lastUpdateTime = System.currentTimeMillis(); // 初始化为当前时间  
+    }
 
     public ObPartitionLocation getPartitionLocation() {
         rwLock.readLock().lock();

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionLocationInfo.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionLocationInfo.java
@@ -28,9 +28,9 @@ public class ObPartitionLocationInfo {
     private Long                  tabletLsId          = OB_INVALID_ID;
     private Long                  lastUpdateTime      = 0L;
     public ReentrantReadWriteLock rwLock              = new ReentrantReadWriteLock();
-    public AtomicBoolean          initialized         = new AtomicBoolean(false);public final CountDownLatch   initializationLatch = new CountDownLatch(1);
-
+    public AtomicBoolean          initialized         = new AtomicBoolean(false);
     public final CountDownLatch   initializationLatch = new CountDownLatch(1);
+    
 
     public ObPartitionLocation getPartitionLocation() {
         rwLock.readLock().lock();
@@ -42,9 +42,14 @@ public class ObPartitionLocationInfo {
     }
 
     public void updateLocation(ObPartitionLocation newLocation, Long tabletLsId) {
-        this.partitionLocation = newLocation;
+        rwLock.writeLock().lock();
+        try {
+            this.partitionLocation = newLocation;
             this.tabletLsId = tabletLsId;
-        this.lastUpdateTime = System.currentTimeMillis();
+            this.lastUpdateTime = System.currentTimeMillis();
+        } finally {
+            rwLock.writeLock().unlock();
+        }
     }
 
     public Long getTabletLsId() {

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionLocationInfo.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/partition/ObPartitionLocationInfo.java
@@ -23,18 +23,14 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.alipay.oceanbase.rpc.protocol.payload.Constants.OB_INVALID_ID;
 
-// 这个类不做线程安全之类的处理
 public class ObPartitionLocationInfo {
     private ObPartitionLocation   partitionLocation   = null;
     private Long                  tabletLsId          = OB_INVALID_ID;
     private Long                  lastUpdateTime      = 0L;
     public ReentrantReadWriteLock rwLock              = new ReentrantReadWriteLock();
-    public AtomicBoolean          initialized         = new AtomicBoolean(false);
-    public final CountDownLatch   initializationLatch = new CountDownLatch(1);
+    public AtomicBoolean          initialized         = new AtomicBoolean(false);public final CountDownLatch   initializationLatch = new CountDownLatch(1);
 
-    public ObPartitionLocationInfo() {
-        this.lastUpdateTime = System.currentTimeMillis(); // 初始化为当前时间  
-    }
+    public final CountDownLatch   initializationLatch = new CountDownLatch(1);
 
     public ObPartitionLocation getPartitionLocation() {
         rwLock.readLock().lock();
@@ -46,14 +42,9 @@ public class ObPartitionLocationInfo {
     }
 
     public void updateLocation(ObPartitionLocation newLocation, Long tabletLsId) {
-        rwLock.writeLock().lock();
-        try {
-            this.partitionLocation = newLocation;
+        this.partitionLocation = newLocation;
             this.tabletLsId = tabletLsId;
-            this.lastUpdateTime = System.currentTimeMillis();
-        } finally {
-            rwLock.writeLock().unlock();
-        }
+        this.lastUpdateTime = System.currentTimeMillis();
     }
 
     public Long getTabletLsId() {

--- a/src/main/java/com/alipay/oceanbase/rpc/property/Property.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/property/Property.java
@@ -113,7 +113,7 @@ public enum Property {
     // [ObTable][RPC]
     RPC_CONNECT_TRY_TIMES("rpc.connect.try.times", 3, "建立RPC连接的尝试次数"),
 
-    RPC_EXECUTE_TIMEOUT("rpc.execute.timeout", 3000, "执行RPC请求的socket超时时间"),
+    RPC_EXECUTE_TIMEOUT("rpc.execute.timeout", 12000, "执行RPC请求的socket超时时间"),
 
     RPC_LOGIN_TIMEOUT("rpc.login.timeout", 1000, "请求RPC登录的超时时间"),
 

--- a/src/main/java/com/alipay/oceanbase/rpc/property/Property.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/property/Property.java
@@ -71,7 +71,7 @@ public enum Property {
     TABLE_ENTRY_REFRESH_INTERNAL_CEILING("table.entry.refresh.internal.ceiling", 1600L,
                                          "刷新TABLE地址的最大时间间隔"),
 
-    TABLE_ENTRY_REFRESH_INTERVAL_WAIT("table.entry.refresh.interval.wait", false,
+    TABLE_ENTRY_REFRESH_INTERVAL_WAIT("table.entry.refresh.interval.wait", true,
                                       "刷新TABLE地址时是否等待间隔时间"),
 
     TABLE_ENTRY_REFRESH_LOCK_TIMEOUT("table.entry.refresh.lock.timeout", 4000L, "刷新TABLE地址的锁超时时间"),

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/ObObjType.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/ObObjType.java
@@ -1350,10 +1350,12 @@ public enum ObObjType {
          * Parse to comparable.
          */
         @Override
-        public Comparable parseToComparable(Object o, ObCollationType ct)
-                                                                         throws IllegalArgumentException,
-                                                                         FeatureNotSupportedException {
-            throw new FeatureNotSupportedException("ObUnknownType is not supported .");
+        public Comparable parseToComparable(Object o, ObCollationType ct) throws IllegalArgumentException{
+            if (o instanceof Long) {
+                return parseLong(this, o, ct);
+            } else{
+                return parseTextToComparable(this, o, ct);
+            }
         }
 
     }, // Min, Max, NOP etc.

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/ObObjType.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/ObObjType.java
@@ -1351,7 +1351,7 @@ public enum ObObjType {
          */
         @Override
         public Comparable parseToComparable(Object o, ObCollationType ct) throws IllegalArgumentException{
-            if (o instanceof Long) {
+            if (o instanceof Number) {
                 return parseLong(this, o, ct);
             } else{
                 return parseTextToComparable(this, o, ct);

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -393,8 +393,6 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
     protected Map<Long, ObPair<Long, ObTableParam>> buildPartitions(ObTableClient client, ObTableQuery tableQuery, String tableName) throws Exception {
         Map<Long, ObPair<Long, ObTableParam>> partitionObTables = new LinkedHashMap<>();
         String indexName = tableQuery.getIndexName();
-        String indexTableName = null;
-
         if (!client.isOdpMode()) {
             indexTableName = client.getIndexTableName(tableName, indexName, tableQuery.getScanRangeColumns(), false);
         }
@@ -446,12 +444,12 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
 
     protected void checkStatus() throws IllegalStateException {
         if (!initialized) {
-            throw new IllegalStateException("table " + tableName
+            throw new IllegalStateException("table " + indexTableName
                                             + "query stream result is not initialized");
         }
 
         if (closed) {
-            throw new IllegalStateException("table " + tableName + " query stream result is closed");
+            throw new IllegalStateException("table " + indexTableName + " query stream result is closed");
         }
     }
 

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -148,6 +148,11 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                         if (failedServerList != null) {
                             route.setBlackList(failedServerList);
                         }
+                        if (ObGlobal.obVsnMajor() >= 4) {
+                            TableEntry tableEntry = client.getOrRefreshTableEntry(indexTableName, false, false, false);
+                            client.refreshTableLocationByTabletId(tableEntry, indexTableName, client.getTabletIdByPartId(tableEntry, partIdWithIndex.getLeft()));
+                        }
+
                         subObTable = client
                             .getTableWithPartId(indexTableName, partIdWithIndex.getLeft(),
                                 needRefreshTableEntry, client.isTableEntryRefreshIntervalWait(),

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -17,11 +17,13 @@
 
 package com.alipay.oceanbase.rpc.protocol.payload.impl.execute.query;
 
+import com.alipay.oceanbase.rpc.ObGlobal;
 import com.alipay.oceanbase.rpc.ObTableClient;
 import com.alipay.oceanbase.rpc.bolt.transport.ObTableConnection;
 import com.alipay.oceanbase.rpc.exception.*;
 import com.alipay.oceanbase.rpc.location.model.ObReadConsistency;
 import com.alipay.oceanbase.rpc.location.model.ObServerRoute;
+import com.alipay.oceanbase.rpc.location.model.TableEntry;
 import com.alipay.oceanbase.rpc.location.model.partition.ObPair;
 import com.alipay.oceanbase.rpc.protocol.payload.AbstractPayload;
 import com.alipay.oceanbase.rpc.protocol.payload.ObPayload;
@@ -348,10 +350,7 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
 
                 } catch (Exception e) {
                     if (e instanceof ObTableNeedFetchAllException) {
-                        // Adjust the start key and refresh the expectant
-                        this.tableQuery.adjustStartKey(currentStartKey);
                         setExpectant(refreshPartition(tableQuery, tableName));
-
                         // Reset the iterator to start over  
                         it = expectant.entrySet().iterator();
                         referPartition.clear(); // Clear the referPartition if needed

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -247,9 +247,8 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                     } else if (e instanceof ObTableException) {
                         if ((((ObTableException) e).getErrorCode() == ResultCodes.OB_TABLE_NOT_EXIST.errorCode || ((ObTableException) e)
                             .getErrorCode() == ResultCodes.OB_NOT_SUPPORTED.errorCode)
-                            && ((request instanceof ObTableQueryAsyncRequest && ((ObTableQueryAsyncRequest) request)
-                                .getObTableQueryRequest().getTableQuery().isHbaseQuery()) || (request instanceof ObTableQueryRequest && ((ObTableQueryRequest) request)
-                                .getTableQuery().isHbaseQuery()))
+                            && ((request instanceof ObTableQueryAsyncRequest && ((ObTableQueryAsyncRequest) request).getObTableQueryRequest().getTableQuery().isHbaseQuery())
+                            || (request instanceof ObTableQueryRequest && ((ObTableQueryRequest) request).getTableQuery().isHbaseQuery()))
                             && client.getTableGroupInverted().get(indexTableName) != null) {
                             // table not exists && hbase mode && table group exists , three condition both
                             client.eraseTableGroupFromCache(tableName);

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -52,7 +52,6 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
     protected volatile boolean                                                 closed              = false;
     protected volatile List<ObObj>                                             row                 = null;
     protected volatile int                                                     rowIndex            = -1;
-    // 调整它的startKey
     protected ObTableQuery                                                     tableQuery;
     protected long                                                             operationTimeout    = -1;
     protected String                                                           tableName;

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -158,7 +158,6 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                     result = subObTable.executeWithConnection(request, connectionRef);
                 } else {
                     result = subObTable.execute(request);
-
                     if (result != null && result.getPcode() == Pcodes.OB_TABLE_API_MOVE) {
                         ObTableApiMove moveResponse = (ObTableApiMove) result;
                         client.getRouteTableRefresher().addTableIfAbsent(indexTableName, true);
@@ -594,7 +593,8 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                                 RUNTIME.error("Fail to get refresh table entry response after {}",
                                         retryTimes);
                                 throw new ObTableRetryExhaustedException(
-                                        "Fail to get refresh table entry response after " + retryTimes);
+                                        "Fail to get refresh table entry response after " + retryTimes +
+                                                "errorCode:" + ((ObTableNeedFetchAllException) e).getErrorCode());
 
                             }
                         } else {

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
@@ -41,7 +41,6 @@ import static com.alipay.oceanbase.rpc.util.TableClientLoggerFactory.RUNTIME;
 public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResult {
     private static final Logger      logger         = LoggerFactory
                                                         .getLogger(ObTableClientQueryStreamResult.class);
-    protected ObTableClient          client;
     private boolean                  isEnd          = true;
     private long                     sessionId      = Constants.OB_INVALID_ID;
     private ObTableQueryAsyncRequest asyncRequest   = new ObTableQueryAsyncRequest();
@@ -363,19 +362,7 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
             closeLastStreamResult(lastEntry.getValue());
         }
     }
-
-    public ObTableClient getClient() {
-        return client;
-    }
-
-    /**
-     * Set client.
-     * @param client client want to set
-     */
-    public void setClient(ObTableClient client) {
-        this.client = client;
-    }
-
+    
     public boolean isEnd() {
         return isEnd;
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
@@ -240,7 +240,7 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
                                     .getTableQuery(), realTableName));
                             setEnd(true);
                         } else {
-                            setExpectant(refreshPartition(this.asyn cRequest.getObTableQueryRequest()
+                            setExpectant(refreshPartition(this.asyncRequest.getObTableQueryRequest()
                                     .getTableQuery(), realTableName));
                         }
                     } else {

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
@@ -17,11 +17,13 @@
 
 package com.alipay.oceanbase.rpc.stream;
 
+import com.alipay.oceanbase.rpc.ObGlobal;
 import com.alipay.oceanbase.rpc.ObTableClient;
 import com.alipay.oceanbase.rpc.bolt.transport.ObTableConnection;
 import com.alipay.oceanbase.rpc.exception.ObTableException;
 import com.alipay.oceanbase.rpc.exception.ObTableNeedFetchAllException;
 import com.alipay.oceanbase.rpc.exception.ObTableRetryExhaustedException;
+import com.alipay.oceanbase.rpc.location.model.TableEntry;
 import com.alipay.oceanbase.rpc.location.model.partition.ObPair;
 import com.alipay.oceanbase.rpc.protocol.payload.Constants;
 import com.alipay.oceanbase.rpc.protocol.payload.ObPayload;
@@ -238,7 +240,7 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
                                     .getTableQuery(), realTableName));
                             setEnd(true);
                         } else {
-                            setExpectant(refreshPartition(this.asyncRequest.getObTableQueryRequest()
+                            setExpectant(refreshPartition(this.asyn cRequest.getObTableQueryRequest()
                                     .getTableQuery(), realTableName));
                         }
                     } else {

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
@@ -228,11 +228,20 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
                 } catch (Exception e) {
                     if (e instanceof ObTableNeedFetchAllException) {
                         String realTableName = client.getPhyTableNameFromTableGroup(entityType, tableName);
-                        this.asyncRequest.getObTableQueryRequest().getTableQuery()
-                            .adjustStartKey(currentStartKey);
-                        setExpectant(refreshPartition(this.asyncRequest.getObTableQueryRequest()
-                            .getTableQuery(), realTableName));
-                        setEnd(true);
+                        TableEntry entry = client.getOrRefreshTableEntry(realTableName, false, false, false);
+                        // Calculate the next partition only when the range partition is affected by a split, based on the keys already scanned.
+                        if (ObGlobal.obVsnMajor() >= 4
+                                && entry.isPartitionTable()
+                                && entry.getPartitionInfo().getFirstPartDesc().getPartFuncType().isRangePart()) {
+                            this.asyncRequest.getObTableQueryRequest().getTableQuery()
+                                    .adjustStartKey(currentStartKey);
+                            setExpectant(refreshPartition(this.asyncRequest.getObTableQueryRequest()
+                                    .getTableQuery(), realTableName));
+                            setEnd(true);
+                        } else {
+                            setExpectant(refreshPartition(this.asyncRequest.getObTableQueryRequest()
+                                    .getTableQuery(), realTableName));
+                        }
                     } else {
                         throw e;
                     }
@@ -260,10 +269,15 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
                 } catch (Exception e) {
                     if (e instanceof ObTableNeedFetchAllException) {
                         String realTableName = client.getPhyTableNameFromTableGroup(entityType, tableName);
-                        this.asyncRequest.getObTableQueryRequest().getTableQuery()
-                            .adjustStartKey(currentStartKey);
-                        setExpectant(refreshPartition(this.asyncRequest.getObTableQueryRequest()
-                            .getTableQuery(), realTableName));
+                        TableEntry tableEntry = client.getOrRefreshTableEntry(realTableName, false, false, false);
+                        if (ObGlobal.obVsnMajor() >= 4
+                            && tableEntry.isPartitionTable()
+                            && tableEntry.getPartitionInfo().getFirstPartDesc().getPartFuncType().isRangePart()) {
+                            this.asyncRequest.getObTableQueryRequest().getTableQuery()
+                                    .adjustStartKey(currentStartKey);
+                            setExpectant(refreshPartition(this.asyncRequest.getObTableQueryRequest()
+                                    .getTableQuery(), realTableName));
+                        }
                         it = expectant.entrySet().iterator();
                         retryTimes++;
                         if (retryTimes > client.getTableEntryRefreshTryTimes()) {

--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryStreamResult.java
@@ -34,10 +34,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ObTableClientQueryStreamResult extends AbstractQueryStreamResult {
-
     private static final Logger logger = TableClientLoggerFactory
                                            .getLogger(ObTableClientQueryStreamResult.class);
-    protected ObTableClient     client;
 
     protected ObTableQueryResult referToNewPartition(ObPair<Long, ObTableParam> partIdWithObTable)
                                                                                                   throws Exception {
@@ -83,20 +81,5 @@ public class ObTableClientQueryStreamResult extends AbstractQueryStreamResult {
                                                                      String tableName)
                                                                                       throws Exception {
         return buildPartitions(client, tableQuery, tableName);
-    }
-
-    /**
-     * Get client.
-     * @return client
-     */
-    public ObTableClient getClient() {
-        return client;
-    }
-
-    /*
-     * Set client.
-     */
-    public void setClient(ObTableClient client) {
-        this.client = client;
     }
 }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -438,12 +438,10 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
                             tableName, partId, ((ObTableException) ex).getErrorCode(), ex);
                     if (obTableClient.isRetryOnChangeMasterTimes()
                         && (tryTimes - 1) < obTableClient.getRuntimeRetryTimes()) {
-                        logger
-                            .warn(
-                                "tablename:{} partition id:{} batch ops retry while meet ObTableMasterChangeException, errorCode: {} , retry times {}",
-                                tableName, partId, ((ObTableException) ex).getErrorCode(),
-                                tryTimes, ex);
                         if (ex instanceof ObTableNeedFetchAllException) {
+                            logger.warn("tablename:{}, partition_id: {}  batch ops retry while meet ObTableNeedFetchAllException, errorCode: {} , retry times {}",
+                                    tableName, subRequest.getPartitionId(),((ObTableException) ex).getErrorCode(),
+                                    tryTimes, ex);
                             // refresh table info
                             obTableClient.getOrRefreshTableEntry(tableName, needRefreshTableEntry,
                                 obTableClient.isTableEntryRefreshIntervalWait(), true);
@@ -558,6 +556,7 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
                         throw e;
                     }
                 }
+                Thread.sleep(obTableClient.getRuntimeRetryInterval());
             }
 
             if (allPartitionsSuccess) {

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -20,6 +20,7 @@ package com.alipay.oceanbase.rpc.table;
 import com.alipay.oceanbase.rpc.ObTableClient;
 import com.alipay.oceanbase.rpc.exception.*;
 import com.alipay.oceanbase.rpc.location.model.ObServerRoute;
+import com.alipay.oceanbase.rpc.location.model.TableEntry;
 import com.alipay.oceanbase.rpc.location.model.partition.ObPair;
 import com.alipay.oceanbase.rpc.mutation.result.*;
 import com.alipay.oceanbase.rpc.protocol.payload.ObPayload;
@@ -365,11 +366,12 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
                         if (failedServerList != null) {
                             route.setBlackList(failedServerList);
                         }
-                        ObTableParam newParam = obTableClient.getTableWithPartId(tableName,
-                                originPartId, needRefreshTableEntry,
-                                obTableClient.isTableEntryRefreshIntervalWait(), needFetchAllRouteInfo,
-                                route).getRight();
-
+                        TableEntry entry = obTableClient.getOrRefreshTableEntry(tableName, false,
+                            false, false);
+                        obTableClient.refreshTableLocationByTabletId(entry, tableName, partId);
+                        ObTableParam newParam = obTableClient.getTableWithPartId(tableName, partId,
+                                false, obTableClient.isTableEntryRefreshIntervalWait(), needFetchAllRouteInfo, route)
+                                .getRight();
                         subObTable = newParam.getObTable();
                         subRequest.setPartitionId(newParam.getPartitionId());
                     }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -17,6 +17,7 @@
 
 package com.alipay.oceanbase.rpc.table;
 
+import com.alipay.oceanbase.rpc.ObGlobal;
 import com.alipay.oceanbase.rpc.ObTableClient;
 import com.alipay.oceanbase.rpc.exception.*;
 import com.alipay.oceanbase.rpc.location.model.ObServerRoute;
@@ -368,7 +369,9 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
                         }
                         TableEntry entry = obTableClient.getOrRefreshTableEntry(tableName, false,
                             false, false);
-                        obTableClient.refreshTableLocationByTabletId(entry, tableName, partId);
+                        if (ObGlobal.obVsnMajor() >= 4) {
+                            obTableClient.refreshTableLocationByTabletId(entry, tableName, partId);
+                        }
                         ObTableParam newParam = obTableClient.getTableWithPartId(tableName, partId,
                                 false, obTableClient.isTableEntryRefreshIntervalWait(), needFetchAllRouteInfo, route)
                                 .getRight();

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -519,6 +519,9 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                                 false, false);
                         if (ObGlobal.obVsnMajor() >= 4) {
                             obTableClient.refreshTableLocationByTabletId(entry, realTableName, obTableClient.getTabletIdByPartId(entry, originPartId));
+                        } else { // 3.x
+                            obTableClient.getOrRefreshTableEntry(realTableName, needRefreshTableEntry,
+                                    obTableClient.isTableEntryRefreshIntervalWait(), false);
                         }
                         subObTable = obTableClient.getTableWithPartId(realTableName, originPartId, needRefreshTableEntry,
                                         obTableClient.isTableEntryRefreshIntervalWait(), false, route).
@@ -571,9 +574,10 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                         }
                     } else {
                         String logMessage = String.format(
-                                "exhaust retry while meet NeedRefresh Exception, table name: %s, ls id: %d, batch ops refresh table, errorCode: %d",
+                                "exhaust retry while meet NeedRefresh Exception, table name: %s, ls id: %d, batch ops refresh table, retry times: %d, errorCode: %d",
                                 realTableName,
                                 lsId,
+                                obTableClient.getRuntimeRetryTimes(),
                                 ((ObTableException) ex).getErrorCode()
                         );
                         logger.warn(logMessage, ex);

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -515,12 +515,12 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                         if (failedServerList != null) {
                             route.setBlackList(failedServerList);
                         }
-                        TableEntry entry = obTableClient.getOrRefreshTableEntry(tableName, false,
+                        TableEntry entry = obTableClient.getOrRefreshTableEntry(realTableName, false,
                                 false, false);
                         if (ObGlobal.obVsnMajor() >= 4) {
-                            obTableClient.refreshTableLocationByTabletId(entry, tableName, obTableClient.getTabletIdByPartId(entry, originPartId));
+                            obTableClient.refreshTableLocationByTabletId(entry, realTableName, obTableClient.getTabletIdByPartId(entry, originPartId));
                         }
-                        subObTable = obTableClient.getTableWithPartId(tableName, originPartId, needRefreshTableEntry,
+                        subObTable = obTableClient.getTableWithPartId(realTableName, originPartId, needRefreshTableEntry,
                                         obTableClient.isTableEntryRefreshIntervalWait(), false, route).
                                             getRight().getObTable();
                     }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -17,6 +17,7 @@
 
 package com.alipay.oceanbase.rpc.table;
 
+import com.alipay.oceanbase.rpc.ObGlobal;
 import com.alipay.oceanbase.rpc.ObTableClient;
 import com.alipay.oceanbase.rpc.checkandmutate.CheckAndInsUp;
 import com.alipay.oceanbase.rpc.exception.*;
@@ -516,7 +517,9 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                         }
                         TableEntry entry = obTableClient.getOrRefreshTableEntry(tableName, false,
                                 false, false);
-                        obTableClient.refreshTableLocationByTabletId(entry, tableName, obTableClient.getTabletIdByPartId(entry, originPartId));
+                        if (ObGlobal.obVsnMajor() >= 4) {
+                            obTableClient.refreshTableLocationByTabletId(entry, tableName, obTableClient.getTabletIdByPartId(entry, originPartId));
+                        }
                         subObTable = obTableClient.getTableWithPartId(tableName, originPartId, needRefreshTableEntry,
                                         obTableClient.isTableEntryRefreshIntervalWait(), false, route).
                                             getRight().getObTable();

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -23,6 +23,7 @@ import com.alipay.oceanbase.rpc.exception.*;
 import com.alipay.oceanbase.rpc.get.Get;
 import com.alipay.oceanbase.rpc.get.result.GetResult;
 import com.alipay.oceanbase.rpc.location.model.ObServerRoute;
+import com.alipay.oceanbase.rpc.location.model.TableEntry;
 import com.alipay.oceanbase.rpc.location.model.partition.ObPair;
 import com.alipay.oceanbase.rpc.mutation.*;
 import com.alipay.oceanbase.rpc.mutation.result.MutationResult;
@@ -513,7 +514,10 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                         if (failedServerList != null) {
                             route.setBlackList(failedServerList);
                         }
-                        subObTable = obTableClient.getTableWithPartId(realTableName, originPartId, needRefreshTableEntry,
+                        TableEntry entry = obTableClient.getOrRefreshTableEntry(tableName, false,
+                                false, false);
+                        obTableClient.refreshTableLocationByTabletId(entry, tableName, obTableClient.getTabletIdByPartId(entry, originPartId));
+                        subObTable = obTableClient.getTableWithPartId(tableName, originPartId, needRefreshTableEntry,
                                         obTableClient.isTableEntryRefreshIntervalWait(), false, route).
                                             getRight().getObTable();
                     }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -566,10 +566,10 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                             realTableName, lsId, ((ObTableException) ex).getErrorCode(), ex);
                     if (obTableClient.isRetryOnChangeMasterTimes()
                             && (tryTimes - 1) < obTableClient.getRuntimeRetryTimes()) {
-                        logger.warn("tablename:{} ls id:{} batch ops retry while meet ObTableMasterChangeException, errorCode: {} , retry times {}",
-                                realTableName, lsId, ((ObTableException) ex).getErrorCode(),
-                                     tryTimes, ex);
                         if (ex instanceof ObTableNeedFetchAllException) {
+                            logger.warn("tablename:{} ls id:{} batch ops retry while meet ObTableNeedFetchAllException, errorCode: {} , retry times {}",
+                                    realTableName, lsId, ((ObTableException) ex).getErrorCode(),
+                                    tryTimes, ex);
                             obTableClient.getOrRefreshTableEntry(realTableName, needRefreshTableEntry,
                                     obTableClient.isTableEntryRefreshIntervalWait(), true);
                             throw ex;
@@ -694,6 +694,7 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                         throw e;
                     }
                 }
+                Thread.sleep(obTableClient.getRuntimeRetryInterval());
             }
 
             if (allPartitionsSuccess) {

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
@@ -264,7 +264,6 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
     public Map<Long, ObPair<Long, ObTableParam>> initPartitions(ObTableQuery tableQuery, String tableName) throws Exception {
         Map<Long, ObPair<Long, ObTableParam>> partitionObTables = new LinkedHashMap<>();
         String indexName = tableQuery.getIndexName();
-        String indexTableName = null;
 
         if (!this.obTableClient.isOdpMode()) {
             indexTableName = obTableClient.getIndexTableName(tableName, indexName, tableQuery.getScanRangeColumns(), false);


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
This feature primarily implements a single-tablet refresh mechanism for table location and adds some retry mechanisms to support the auto-splitting feature.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->

- The table location management in 4.x is separated and managed independently using ObPartitionLocationInfo, with index management based on tablet IDs in ObPartitionEntry.
- The refresh of metadata and the refresh of location are decoupled into **two phases**. When a routing change is encountered, the location information is refreshed at a single-tablet granularity.
- A retry mechanism has been added to refresh the entire table entry for certain error codes and appropriately handle requests that require retries (e.g., splitting and recombining batches) to ensure the reliability and correctness of the retries.
