### PR TITLE
fix error hbase table name because of the lack of indexTableName

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -231,10 +231,11 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                         }
                     } else if (e instanceof ObTableException) {
                         if ((((ObTableException) e).getErrorCode() == ResultCodes.OB_TABLE_NOT_EXIST.errorCode || ((ObTableException) e)
-                                .getErrorCode() == ResultCodes.OB_NOT_SUPPORTED.errorCode)
-                                && ((request instanceof ObTableQueryAsyncRequest && ((ObTableQueryAsyncRequest) request).getObTableQueryRequest().getTableQuery().isHbaseQuery())
-                                || (request instanceof ObTableQueryRequest && ((ObTableQueryRequest) request).getTableQuery().isHbaseQuery()))
-                                && client.getTableGroupInverted().get(indexTableName) != null) {
+                            .getErrorCode() == ResultCodes.OB_NOT_SUPPORTED.errorCode)
+                            && ((request instanceof ObTableQueryAsyncRequest && ((ObTableQueryAsyncRequest) request)
+                                .getObTableQueryRequest().getTableQuery().isHbaseQuery()) || (request instanceof ObTableQueryRequest && ((ObTableQueryRequest) request)
+                                .getTableQuery().isHbaseQuery()))
+                            && client.getTableGroupInverted().get(indexTableName) != null) {
                             // table not exists && hbase mode && table group exists , three condition both
                             client.eraseTableGroupFromCache(tableName);
                         }
@@ -254,7 +255,7 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                                         ((ObTableException) e).getErrorCode(), tryTimes, e);
                                 // tablet not exists, refresh table entry
                                 if (e instanceof ObTableNeedFetchAllException) {
-                                    client.getOrRefreshTableEntry(tableName, true, true, true);
+                                    client.getOrRefreshTableEntry(indexTableName, true, true, true);
                                     throw e;
                                 }
                             } else {

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
@@ -241,6 +241,7 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
 
         if (!this.obTableClient.isOdpMode()) {
             indexTableName = obTableClient.getIndexTableName(tableName, indexName, tableQuery.getScanRangeColumns(), false);
+            this.indexTableName = indexTableName;
         }
 
         for (ObNewRange range : tableQuery.getKeyRanges()) {
@@ -262,6 +263,7 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
             }
             if (this.entityType == ObTableEntityType.HKV && obTableClient.isTableGroupName(tableName)) {
                 indexTableName = obTableClient.tryGetTableNameFromTableGroupCache(tableName, false);
+                this.indexTableName = indexTableName;
             }
             ObBorderFlag borderFlag = range.getBorderFlag();
             List<ObPair<Long, ObTableParam>> pairs = this.obTableClient.getTables(indexTableName,


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
The indexName in quey process is the real tableName. Need to set the indexName and get tableEntry.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
