### PR TITLE
change RPC_OPERATION_TIMEOUT default value from 10 seconds to 2 second

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/property/Property.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/property/Property.java
@@ -119,7 +119,7 @@ public enum Property {
 
     RPC_LOGIN_TRY_TIMES("rpc.login.try.times", 3, "请求RPC登录的尝试次数"),
 
-    RPC_OPERATION_TIMEOUT("rpc.operation.timeout", 10000L, "OB内部执行RPC请求的超时时间"),
+    RPC_OPERATION_TIMEOUT("rpc.operation.timeout", 2000L, "OB内部执行RPC请求的超时时间"),
 
     // [ObTable][CONNECTION_POOL]
     SERVER_CONNECTION_POOL_SIZE("server.connection.pool.size", 1, "单个SERVER的连接数"),


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

- change RPC_OPERATION_TIMEOUT default value from 10 seconds to 2 second


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
