### PR TITLE
Fix compatibility problem caused by getPartition in ODP mode

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -618,7 +618,6 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             throw new IllegalArgumentException("table name is null");
         }
         boolean needRefreshTableEntry = false;
-        boolean needRenew = false;
         boolean needFetchAllRouteInfo = false;
         int tryTimes = 0;
         long startExecute = System.currentTimeMillis();
@@ -636,7 +635,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             ObPair<Long, ObTableParam> obPair = null;
             try {
                 if (odpMode) {
-                    obPair = getODPTableWithRowKeyValue(tableName, callback.getRowKey(), needRenew);
+                    obPair = new ObPair<Long, ObTableParam>(0L, new ObTableParam(odpTable));
                 } else {
                     obPair = getTable(tableName, callback.getRowKey(),
                         needRefreshTableEntry, tableEntryRefreshIntervalWait,
@@ -654,17 +653,9 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                                     "execute while meet Exception, errorCode: {} , errorMsg: {}, try times {}",
                                     ((ObTableException) ex).getErrorCode(), ex.getMessage(),
                                     tryTimes);
-                            // if the cause is that ODP partition meta have expired, try to fetch new one
-                            if (ex instanceof ObTablePartitionChangeException
-                                && ((ObTablePartitionChangeException) ex).getErrorCode() == OB_ERR_KV_ROUTE_ENTRY_EXPIRE.errorCode) {
-                                needRenew = true;
-                            } else {
-                                throw ex;
-                            }
                         } else {
                             logger.warn("execute while meet Exception, errorMsg: {}, try times {}",
                                 ex.getMessage(), tryTimes);
-                            throw ex;
                         }
                     } else {
                         RUNTIME.error("retry failed with exception", ex);
@@ -686,7 +677,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                     } else if (ex instanceof ObTableException
                                && ((ObTableException) ex).isNeedRefreshTableEntry()) {
                         needRefreshTableEntry = true;
-                        
+
                         if (retryOnChangeMasterTimes && (tryTimes - 1) < runtimeRetryTimes) {
                             if (ex instanceof ObTableNeedFetchAllException) {
                                 needFetchAllRouteInfo = true;
@@ -787,7 +778,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             throw new IllegalArgumentException("table name is null");
         }
         boolean needRefreshTableEntry = false;
-        boolean needRenew = false;
+        boolean needFetchAllRouteInfo = false;
         int tryTimes = 0;
         long startExecute = System.currentTimeMillis();
         while (true) {
@@ -804,7 +795,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             ObPair<Long, ObTableParam> obPair = null;
             try {
                 if (odpMode) {
-                    obPair = getODPTableWithRowKey(tableName, callback.getRowKey(), needRenew);
+                    obPair = new ObPair<Long, ObTableParam>(0L, new ObTableParam(odpTable));
                 } else {
                     if (null != callback.getRowKey()) {
                         // in the case of retry, the location always needs to be refreshed here
@@ -837,20 +828,10 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                                     "execute while meet Exception, errorCode: {} , errorMsg: {}, try times {}",
                                     ((ObTableException) ex).getErrorCode(), ex.getMessage(),
                                     tryTimes);
-                            // if the cause is that ODP partition meta have expired, try to fetch new one  
-                            if (ex instanceof ObTablePartitionChangeException
-                                    && ((ObTablePartitionChangeException) ex).getErrorCode() == OB_ERR_KV_ROUTE_ENTRY_EXPIRE.errorCode) {
-                                needRenew = true;
-                            } else {
-                                RUNTIME.error("execute while meet exception", ex);
-                                throw ex;
-                            }
                         } else {
                             logger.warn(
-                                    "execute while meet Exception, exception: {}, try times {}", ex,
-                                    tryTimes);
-                            RUNTIME.error("execute while meet exception", ex);
-                            throw ex;
+                                "execute while meet Exception, exception: {}, try times {}", ex,
+                                tryTimes);
                         }
                     } else {
                         RUNTIME.error("retry failed with exception", ex);
@@ -870,7 +851,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                         }
                     } else if (ex instanceof ObTableException
                             && ((ObTableException) ex).isNeedRefreshTableEntry()) {
-                        // if the problem is the lack of row key name, throw directly  
+                        // if the problem is the lack of row key name, throw directly
                         if (tableRowKeyElement.get(tableName) == null) {
                             logger.warn("tableRowKeyElement not found table name: {}", ex.getMessage());
                             RUNTIME.error("tableRowKeyElement not found table name", ex);
@@ -880,7 +861,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                         if (retryOnChangeMasterTimes && (tryTimes - 1) < runtimeRetryTimes) {
                             if (ex instanceof ObTableNeedFetchAllException) {
                                 getOrRefreshTableEntry(tableName, true, true, true);
-                                // reset failure count while fetch all route info  
+                                // reset failure count while fetch all route info
                                 this.resetExecuteContinuousFailureCount(tableName);
                             }
                         } else {
@@ -1374,13 +1355,13 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             if (info == null) {
                 throw new ObTableEntryRefreshException("Partition info is null for tabletId=" + tabletId);
             }
-            
+
             long lastRefreshTime = info.getLastUpdateTime();
             long currentTime = System.currentTimeMillis();
             if (currentTime - lastRefreshTime < tableEntryRefreshIntervalCeiling) {
                 return tableEntry;
             }
-            
+
             Lock lock = info.refreshLock;
             boolean acquired = false;
             try {
@@ -1400,7 +1381,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                 if (currentTime - lastRefreshTime < tableEntryRefreshIntervalCeiling) {
                     return tableEntry;
                 }
-                
+
                 tableEntry = loadTableEntryLocationWithPriority(
                         serverRoster,
                         tableEntryKey,
@@ -1412,7 +1393,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                         serverAddressCachingTimeout,
                         sysUA
                 );
-                
+
                 tableEntry.prepareForWeakRead(serverRoster.getServerLdcLocation());
 
             } finally {
@@ -1430,7 +1411,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             RUNTIME.error(LCD.convert("01-00020"), tableEntryKey, tableEntry, e);
             throw new ObTableEntryRefreshException(errorMsg, e);
         }
-        
+
         tableLocations.put(tableName, tableEntry);
         tableEntryRefreshContinuousFailureCount.set(0);
         return tableEntry;
@@ -1655,7 +1636,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
     private ReplicaLocation getPartitionLocation(TableEntry tableEntry, long partId,
                                                  ObServerRoute route) {
         // In all cases for 3.x and for non-partitioned tables in 4.x, partId will not change.
-        // If it is 4.x, it will be converted to tablet id. 
+        // If it is 4.x, it will be converted to tablet id.
         partId = getTabletIdByPartId(tableEntry, partId);
         return tableEntry.getPartitionEntry().getPartitionLocationWithTabletId(partId)
             .getReplica(route);
@@ -1980,9 +1961,9 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             obPartitionLocationInfo = getOrRefreshPartitionInfo(tableEntry, tableName, tabletId);
             replica = getPartitionLocation(obPartitionLocationInfo, route);
             /**
-             * Normally, getOrRefreshPartitionInfo makes sure that a thread only continues if it finds the leader  
-             * during a route refresh. But sometimes, there might not be a leader yet. In this case, the thread  
-             * is released, and since it can't get the replica, it throws an no master exception.  
+             * Normally, getOrRefreshPartitionInfo makes sure that a thread only continues if it finds the leader
+             * during a route refresh. But sometimes, there might not be a leader yet. In this case, the thread
+             * is released, and since it can't get the replica, it throws an no master exception.
              */
             if (replica == null && obPartitionLocationInfo.getPartitionLocation().getLeader() == null) {
                 RUNTIME.error(LCD.convert("01-00028"), partitionId, tableEntry.getPartitionEntry(), tableEntry);
@@ -2023,14 +2004,14 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                     tableEntry = getOrRefreshTableEntry(tableName, true, waitForRefresh, false);
                 }
             }
-            
+
             if (ObGlobal.obVsnMajor() >= 4) {
                 obPartitionLocationInfo = getOrRefreshPartitionInfo(tableEntry, tableName, tabletId);
                 replica = getPartitionLocation(obPartitionLocationInfo, route);
             } else {
                 replica = getPartitionReplica(tableEntry, partitionId, route).getRight();
             }
-            
+
             addr = replica.getAddr();
             obTable = tableRoster.get(addr);
 

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1213,7 +1213,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             if ((fetchAll && (fetchAllInterval < punishInterval))
                 || (!fetchAll && (interval < punishInterval))) {
                 if (waitForRefresh) {
-                    long toHoldTime = punishInterval - interval;
+                    long toHoldTime = fetchAll ? (punishInterval - fetchAllInterval) : (punishInterval - interval);
                     logger
                         .info(
                             "punish table entry {} : table entry refresh time {} punish interval {} current time {}. wait for refresh times {}ms",

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -62,7 +62,6 @@ import static com.alipay.oceanbase.rpc.location.model.ObServerRoute.STRONG_READ;
 import static com.alipay.oceanbase.rpc.location.model.TableEntry.HBASE_ROW_KEY_ELEMENT;
 import static com.alipay.oceanbase.rpc.location.model.partition.ObPartIdCalculator.*;
 import static com.alipay.oceanbase.rpc.property.Property.*;
-import static com.alipay.oceanbase.rpc.protocol.payload.ResultCodes.OB_ERR_KV_ROUTE_ENTRY_EXPIRE;
 import static com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObTableOperationType.*;
 import static com.alipay.oceanbase.rpc.util.TableClientLoggerFactory.*;
 import static java.lang.String.format;
@@ -2315,8 +2314,9 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             ObTableParam param = new ObTableParam(obTable);
             param.setPartId(partId);
             partId = getTabletIdByPartId(tableEntry, partId);
-            param.setLsId(tableEntry.getPartitionEntry().getPartitionInfo(partId).getTabletLsId());
-
+            if (ObGlobal.obVsnMajor() >= 4 && tableEntry != null) {
+                param.setLsId(tableEntry.getPartitionEntry().getPartitionInfo(partId).getTabletLsId());
+            }
             param.setTableId(tableEntry.getTableId());
             // real partition(tablet) id
             param.setPartitionId(partId);

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -116,7 +116,6 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
         ObPayload result;
         ObTable subObTable = partIdWithIndex.getRight().getObTable();
         boolean needRefreshTableEntry = false;
-        boolean odpNeedRenew = false;
         int tryTimes = 0;
         long startExecute = System.currentTimeMillis();
         Set<String> failedServerList = null;
@@ -138,9 +137,7 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
             try {
                 if (tryTimes > 1) {
                     if (client.isOdpMode()) {
-                        subObTable = client
-                            .getODPTableWithPartId(tableName, partIdWithIndex.getLeft(),
-                                odpNeedRenew).getRight().getObTable();
+                        subObTable = client.getOdpTable();
                     } else {
                         if (route == null) {
                             route = client.getReadRoute();
@@ -192,24 +189,16 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                                     "tablename:{} stream query execute while meet Exception needing retry, errorCode: {}, errorMsg: {}, try times {}",
                                     indexTableName, ((ObTableException) e).getErrorCode(),
                                     e.getMessage(), tryTimes);
-                            if (e instanceof ObTablePartitionChangeException
-                                && ((ObTablePartitionChangeException) e).getErrorCode() == ResultCodes.OB_ERR_KV_ROUTE_ENTRY_EXPIRE.errorCode) {
-                                odpNeedRenew = true;
-                            } else {
-                                throw e;
-                            }
                         } else if (e instanceof IllegalArgumentException) {
                             logger
                                 .warn(
                                     "tablename:{} stream query execute while meet Exception needing retry, try times {}, errorMsg: {}",
                                     indexTableName, tryTimes, e.getMessage());
-                            throw e;
                         } else {
                             logger
                                 .warn(
                                     "tablename:{} stream query execute while meet Exception needing retry, try times {}",
                                     indexTableName, tryTimes, e);
-                            throw e;
                         }
                     } else {
                         throw e;

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -391,7 +391,6 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
             } catch (Exception ex) {
                 if (obTableClient.isOdpMode()) {
                     if ((tryTimes - 1) < obTableClient.getRuntimeRetryTimes()) {
-                        assert ex instanceof ObTableException;
                         logger
                             .warn(
                                 "batch ops execute while meet Exception, tablename:{}, errorMsg: {}, try times {}",

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
@@ -171,8 +171,8 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
                 }
             }
             if (getPartId() != null && tableQuery.getIndexName() == null) {
+                String realTableName = tableName;
                 try {
-                    String realTableName = tableName;
                     if (this.entityType == ObTableEntityType.HKV
                             && obTableClient.isTableGroupName(tableName)) {
                         indexTableName = obTableClient.tryGetTableNameFromTableGroupCache(tableName,
@@ -190,7 +190,7 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
                         } else if (((ObTableException) e).getErrorCode() == ResultCodes.OB_ERR_KV_ROUTE_ENTRY_EXPIRE.errorCode) {
                             // retry one time with force-renew flag
                             ObPair<Long, ObTableParam> odpTable = obTableClient.getODPTableWithPartId(
-                                    tableName, getPartId(), true);
+                                    realTableName, getPartId(), true);
                             partitionObTables.put(odpTable.getLeft(), odpTable);
                         } else {
                             throw e;
@@ -199,7 +199,7 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
                         throw e;
                     }
                 }
-            }  else {
+            } else {
                 partitionObTables.put(0L, new ObPair<Long, ObTableParam>(0L, new ObTableParam(
                         obTableClient.getOdpTable())));
             }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
@@ -187,6 +187,13 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
                         if (((ObTableException) e).getErrorCode() == ResultCodes.OB_NOT_SUPPORTED.errorCode) {
                             // current ODP version does not support get partition meta information
                             throw new FeatureNotSupportedException("current ODP version does not support query with part id", e);
+                        } else if (((ObTableException) e).getErrorCode() == ResultCodes.OB_ERR_KV_ROUTE_ENTRY_EXPIRE.errorCode) {
+                            // retry one time with force-renew flag
+                            ObPair<Long, ObTableParam> odpTable = obTableClient.getODPTableWithPartId(
+                                    tableName, getPartId(), true);
+                            partitionObTables.put(odpTable.getLeft(), odpTable);
+                        } else {
+                            throw e;
                         }
                     } else {
                         throw e;

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
@@ -18,6 +18,7 @@
 package com.alipay.oceanbase.rpc.table;
 
 import com.alipay.oceanbase.rpc.ObTableClient;
+import com.alipay.oceanbase.rpc.exception.FeatureNotSupportedException;
 import com.alipay.oceanbase.rpc.exception.ObTableException;
 import com.alipay.oceanbase.rpc.location.model.partition.ObPair;
 import com.alipay.oceanbase.rpc.mutation.Row;
@@ -169,22 +170,31 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
                     throw new ObTableException("key range columns must be specified when use index");
                 }
             }
-            if (tableQuery.getIndexName() != null) {
-                this.partitionObTables.put(0L, new ObPair<Long, ObTableParam>(0L, new ObTableParam(
-                    obTableClient.getOdpTable())));
-            } else if (getPartId() == null) {
-                initPartitions();
-            } else {
-                String realTableName = tableName;
-                if (this.entityType == ObTableEntityType.HKV
-                    && obTableClient.isTableGroupName(tableName)) {
-                    indexTableName = obTableClient.tryGetTableNameFromTableGroupCache(tableName,
-                        false);
-                    realTableName = indexTableName;
+            if (getPartId() != null && tableQuery.getIndexName() == null) {
+                try {
+                    String realTableName = tableName;
+                    if (this.entityType == ObTableEntityType.HKV
+                            && obTableClient.isTableGroupName(tableName)) {
+                        indexTableName = obTableClient.tryGetTableNameFromTableGroupCache(tableName,
+                                false);
+                        realTableName = indexTableName;
+                    }
+                    ObPair<Long, ObTableParam> odpTable = obTableClient.getODPTableWithPartId(
+                            realTableName, getPartId(), false);
+                    partitionObTables.put(odpTable.getLeft(), odpTable);
+                } catch (Exception e) {
+                    if (e instanceof ObTableException) {
+                        if (((ObTableException) e).getErrorCode() == ResultCodes.OB_NOT_SUPPORTED.errorCode) {
+                            // current ODP version does not support get partition meta information
+                            throw new FeatureNotSupportedException("current ODP version does not support query with part id", e);
+                        }
+                    } else {
+                        throw e;
+                    }
                 }
-                ObPair<Long, ObTableParam> odpTable = obTableClient.getODPTableWithPartId(
-                    realTableName, getPartId(), false);
-                this.partitionObTables.put(odpTable.getLeft(), odpTable);
+            }  else {
+                partitionObTables.put(0L, new ObPair<Long, ObTableParam>(0L, new ObTableParam(
+                        obTableClient.getOdpTable())));
             }
         } else {
             if (getPartId() == null) {
@@ -267,7 +277,6 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
 
         if (!this.obTableClient.isOdpMode()) {
             indexTableName = obTableClient.getIndexTableName(tableName, indexName, tableQuery.getScanRangeColumns(), false);
-            this.indexTableName = indexTableName;
         }
 
         for (ObNewRange range : tableQuery.getKeyRanges()) {
@@ -289,18 +298,11 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
             }
             if (this.entityType == ObTableEntityType.HKV && obTableClient.isTableGroupName(tableName)) {
                 indexTableName = obTableClient.tryGetTableNameFromTableGroupCache(tableName, false);
-                this.indexTableName = indexTableName;
             }
             ObBorderFlag borderFlag = range.getBorderFlag();
             // pairs -> List<Pair<logicId, param>>
-            List<ObPair<Long, ObTableParam>> pairs = null;
-            if (!this.obTableClient.isOdpMode()) {
-                pairs = this.obTableClient.getTables(indexTableName, tableQuery, start,
-                    borderFlag.isInclusiveStart(), end, borderFlag.isInclusiveEnd(), false, false);
-            } else {
-                pairs = this.obTableClient.getOdpTables(tableName, tableQuery, start,
-                    borderFlag.isInclusiveStart(), end, borderFlag.isInclusiveEnd(), false);
-            }
+            List<ObPair<Long, ObTableParam>> pairs = this.obTableClient.getTables(indexTableName, tableQuery, start,
+                borderFlag.isInclusiveStart(), end, borderFlag.isInclusiveEnd(), false, false);
             if (tableQuery.getScanOrder() == ObScanOrder.Reverse) {
                 for (int i = pairs.size() - 1; i >= 0; i--) {
                     partitionObTables.put(pairs.get(i).getLeft(), pairs.get(i));

--- a/src/test/java/com/alipay/oceanbase/rpc/ObGetPartitionTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObGetPartitionTest.java
@@ -17,20 +17,13 @@
 
 package com.alipay.oceanbase.rpc;
 
-import com.alipay.oceanbase.rpc.exception.ObTableException;
 import com.alipay.oceanbase.rpc.location.model.partition.Partition;
 import com.alipay.oceanbase.rpc.mutation.*;
 import com.alipay.oceanbase.rpc.mutation.result.BatchOperationResult;
 import com.alipay.oceanbase.rpc.mutation.result.MutationResult;
-import com.alipay.oceanbase.rpc.property.Property;
-import com.alipay.oceanbase.rpc.protocol.payload.impl.ObObj;
 import com.alipay.oceanbase.rpc.stream.QueryResultSet;
 import com.alipay.oceanbase.rpc.table.api.TableBatchOps;
-import com.alipay.oceanbase.rpc.table.api.TableQuery;
-import com.alipay.oceanbase.rpc.threadlocal.ThreadLocalMap;
 import com.alipay.oceanbase.rpc.util.ObTableClientTestUtil;
-import net.bytebuddy.implementation.auxiliary.MethodCallProxy;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,9 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.alipay.oceanbase.rpc.mutation.MutationFactory.*;
 import static com.alipay.oceanbase.rpc.util.ObTableClientTestUtil.cleanTable;
 import static com.alipay.oceanbase.rpc.util.ObTableClientTestUtil.generateRandomStringByUUID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 public class ObGetPartitionTest {
 
     public ObTableClient        client;


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
This merge fixes compatibility problem caused by getPartition in ODP mode. The ODP versions before 4.3.2 does not support getPartition function and query with part_id. The ODP versions before 4.3.2 will return OB_NOT_SUPPORT if using these two functions. Other functions are not impacted.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
