### PR TITLE
Revert the default connection pool size to 1

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/property/Property.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/property/Property.java
@@ -122,7 +122,7 @@ public enum Property {
     RPC_OPERATION_TIMEOUT("rpc.operation.timeout", 2000L, "OB内部执行RPC请求的超时时间"),
 
     // [ObTable][CONNECTION_POOL]
-    SERVER_CONNECTION_POOL_SIZE("server.connection.pool.size", 10, "单个SERVER的连接数"),
+    SERVER_CONNECTION_POOL_SIZE("server.connection.pool.size", 1, "单个SERVER的连接数"),
 
     // [ObTable][NETTY]
     // overwrite the global default netty watermark for ob table: [512K, 1M]


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

- Revert the default connection pool size to 1, cause performance rollback


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
