### PR TITLE
refresh route table when server return OB_GTS_NOT_READY

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableRemoting.java
@@ -199,6 +199,7 @@ public class ObTableRemoting extends BaseRemoting {
                || errorCode == ResultCodes.OB_SNAPSHOT_DISCARDED.errorCode
                || errorCode == ResultCodes.OB_SCHEMA_EAGAIN.errorCode
                 || errorCode == ResultCodes.OB_ERR_WAIT_REMOTE_SCHEMA_REFRESH.errorCode
+                || errorCode == ResultCodes.OB_GTS_NOT_READY.errorCode
                || (pcode == Pcodes.OB_TABLE_API_LS_EXECUTE && errorCode == ResultCodes.OB_NOT_MASTER.errorCode);
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

- refresh route table when server return OB_GTS_NOT_READY, same with go client


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
