### PR TITLE
modify direct-load MAX_QUERY_TIMEOUT to Integer.MAX_VALUE

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/direct_load/ObDirectLoadStatement.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/direct_load/ObDirectLoadStatement.java
@@ -309,7 +309,7 @@ public class ObDirectLoadStatement {
         private long                         maxErrorRowCount  = 0;
         private String                       loadMethod        = "full";
 
-        private static final long            MAX_QUERY_TIMEOUT = 1L * 365 * 24 * 3600 * 1000;     // 1year
+        private static final long            MAX_QUERY_TIMEOUT = Integer.MAX_VALUE;
 
         Builder(ObDirectLoadConnection connection) {
             this.connection = connection;


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
modify direct-load MAX_QUERY_TIMEOUT to Integer.MAX_VALUE


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
modify direct-load MAX_QUERY_TIMEOUT to INT_MAX, to avoid issues with incorrect parameter settings due to the MAX_QUERY_TIMEOUT being set beyond the integer limit.