### PR TITLE
support sync server capacity and negate expr

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -4245,6 +4245,15 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         }
     }
 
+    private ObTableServerCapacity getServerCapacity() {
+        if (tableRoster.isEmpty()) {
+            throw new IllegalStateException("client is not initialized and obTable is empty");
+        }
+        Iterator<ObTable> iterator = tableRoster.values().iterator();
+        ObTable firstObTable = iterator.next();
+        return firstObTable.getServerCapacity();
+    }
+
     public void setOdpAddr(String odpAddr) {
         this.odpAddr = odpAddr;
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableConnection.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableConnection.java
@@ -171,6 +171,7 @@ public class ObTableConnection {
                 if (result != null && result.getCredential() != null
                     && result.getCredential().length() > 0) {
                     credential = result.getCredential();
+                    obTable.setServerCapacity(result.getServerCapabilities());
                     tenantId = result.getTenantId();
                     // Set version if missing
                     if (ObGlobal.obVsnMajor() == 0) {

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/column/ObGeneratedColumnNegateFunc.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/column/ObGeneratedColumnNegateFunc.java
@@ -1,0 +1,93 @@
+/*-
+ * #%L
+ * OBKV Table Client Framework
+ * %%
+ * Copyright (C) 2021 OceanBase
+ * %%
+ * OBKV Table Client Framework is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ * #L%
+ */
+
+package com.alipay.oceanbase.rpc.protocol.payload.impl.column;
+
+import com.alipay.oceanbase.rpc.protocol.payload.impl.ObCollationType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ObGeneratedColumnNegateFunc implements ObGeneratedColumnSimpleFunc {
+    private final List<String> refColumnNames;
+
+    /*
+     * Ob generated column refer func.
+     */
+    public ObGeneratedColumnNegateFunc(String refColumn) {
+        List<String> refColumnNameList = new ArrayList<String>(1);
+        refColumnNameList.add(refColumn);
+        this.refColumnNames = refColumnNameList;
+    }
+
+    /*
+     * Set parameters.
+     */
+    @Override
+    public void setParameters(List<Object> parameters) {
+        //ignore
+    }
+
+    /*
+     * Get min parameters.
+     */
+    @Override
+    public int getMinParameters() {
+        return 0;
+    }
+
+    /*
+     * Get max parameters.
+     */
+    @Override
+    public int getMaxParameters() {
+        return 0;
+    }
+
+    /*
+     * Get ref column names.
+     */
+    @Override
+    public List<String> getRefColumnNames() {
+        return refColumnNames;
+    }
+
+    /*
+     * Eval value.
+     */
+    @Override
+    public Object evalValue(ObCollationType collationType, Object... refs)
+            throws IllegalArgumentException {
+        if (refs == null || refs.length == 0) {
+            throw new IllegalArgumentException("Input references cannot be null or empty");
+        }
+        Object ref = refs[0];
+        if (ref instanceof Long) {
+            return -(Long)ref;
+        } else if (ref instanceof Integer) {
+            Integer value = (Integer) ref;
+            if (value == Integer.MIN_VALUE) {
+                throw new IllegalArgumentException("The currently provided parameter is the " +
+                        "minimum value of the Integer type, and its negation will cause an overflow.");
+            }
+            return -(Integer) value;
+        } else {
+            throw new IllegalArgumentException("Object [" + ref + "] can not evaluate by" +
+                    " ObGeneratedColumnNegateFunc");
+        }
+    }
+}

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/parser/ObGeneratedColumnExpressParser.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/parser/ObGeneratedColumnExpressParser.java
@@ -18,6 +18,7 @@
 package com.alipay.oceanbase.rpc.protocol.payload.impl.parser;
 
 import com.alipay.oceanbase.rpc.exception.GenerateColumnParseException;
+import com.alipay.oceanbase.rpc.protocol.payload.impl.column.ObGeneratedColumnNegateFunc;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.column.ObGeneratedColumnReferFunc;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.column.ObGeneratedColumnSimpleFunc;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.column.ObGeneratedColumnSubStrFunc;
@@ -66,6 +67,10 @@ public class ObGeneratedColumnExpressParser {
                     default:
                         throw new GenerateColumnParseException("");
                 }
+            case SUB:
+                // If the first token is a '-' sign, then generate the opposite number expression.
+                String refColumn = lexer.stringVal();
+                return new ObGeneratedColumnNegateFunc(refColumn);
             default:
                 throw new GenerateColumnParseException("ERROR. token :  " + lexer.token()
                                                        + ", pos : " + lexer.pos());

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTable.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTable.java
@@ -62,6 +62,8 @@ public class ObTable extends AbstractObTable implements Lifecycle {
     private ConnectionFactory     connectionFactory;
     private ObTableRemoting       realClient;
     private ObTableConnectionPool connectionPool;
+
+    private ObTableServerCapacity serverCapacity = new ObTableServerCapacity();
     
     private Map<String, Object> configs;
 
@@ -512,6 +514,20 @@ public class ObTable extends AbstractObTable implements Lifecycle {
      */
     public void setPort(int port) {
         this.port = port;
+    }
+
+    /*
+     * Get server capacity.
+     */
+    public ObTableServerCapacity getServerCapacity() {
+        return serverCapacity;
+    }
+
+    /*
+     * Set server capacity.
+     */
+    public void setServerCapacity(int flags) {
+        serverCapacity.setFlags(flags);
     }
 
     /*

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableServerCapacity.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableServerCapacity.java
@@ -1,0 +1,44 @@
+/*-
+ * #%L
+ * OBKV Table Client Framework
+ * %%
+ * Copyright (C) 2021 OceanBase
+ * %%
+ * OBKV Table Client Framework is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ * #L%
+ */
+
+package com.alipay.oceanbase.rpc.table;
+
+public class ObTableServerCapacity {
+    private static final int DISTRIBUTED_EXECUTE = 1 << 0;
+    private static final int SECONDARY_PARTITION = 1 << 1;
+    private static final int TIME_SERIES         = 1 << 2;
+    private static final int CAPACITY_MAX        = 1 << 31;
+    private              int flags               = 0;
+
+    public int getFlags() { return flags; }
+
+    public void setFlags(int flags) {
+        this.flags = flags;
+    }
+
+    public boolean isSupportDistributedExecute() {
+        return (flags & DISTRIBUTED_EXECUTE) != 0;
+    }
+
+    public boolean isSupportSecondaryPartition() {
+        return (flags & SECONDARY_PARTITION) != 0;
+    }
+
+    public boolean isSupportTimeSeries() {
+        return (flags & TIME_SERIES) != 0;
+    }
+}

--- a/src/test/java/com/alipay/oceanbase/rpc/protocol/payload/impl/column/ObGeneratedColumnNegateFuncTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/protocol/payload/impl/column/ObGeneratedColumnNegateFuncTest.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * OBKV Table Client Framework
+ * %%
+ * Copyright (C) 2021 OceanBase
+ * %%
+ * OBKV Table Client Framework is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ * #L%
+ */
+
+package com.alipay.oceanbase.rpc.protocol.payload.impl.column;
+
+import com.alipay.oceanbase.rpc.protocol.payload.impl.ObCollationType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ObGeneratedColumnNegateFuncTest {
+    @Test
+    public void testEval() {
+        ObGeneratedColumnSimpleFunc func = new ObGeneratedColumnNegateFunc("K");
+        Assert.assertEquals(-1L, func.evalValue(ObCollationType.CS_TYPE_INVALID, 1L));
+        Assert.assertEquals(-11L, func.evalValue(ObCollationType.CS_TYPE_INVALID, 11L));
+        Assert.assertEquals(-111,
+                func.evalValue(ObCollationType.CS_TYPE_INVALID, 111));
+        Assert.assertEquals(1111L,
+                func.evalValue(ObCollationType.CS_TYPE_INVALID, -1111L));
+        Assert.assertEquals(11111L,
+                func.evalValue(ObCollationType.CS_TYPE_INVALID, -11111L));
+        try {
+            func.evalValue(ObCollationType.CS_TYPE_INVALID, Integer.MIN_VALUE);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("The currently provided parameter is the " +
+                    "minimum value of the Integer type, and its negation will cause an overflow."));
+        }
+        List<String> refColumns = new ArrayList<String>();
+        refColumns.add("K");
+        Assert.assertEquals(refColumns, func.getRefColumnNames());
+    }
+}


### PR DESCRIPTION
## Summary
support sync server capacity and negate expr


## Solution Description
Added support for parsing negation expressions, and enhanced the server-side capabilities in the `obTable`. Each time the server capability is evaluated, the `serverCapacity` is retrieved from the `obTable` for assessment.
