### PR TITLE
Fix issue where low traffic prevents timely detection and refresh of RS when the peer goes offline

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1309,6 +1309,10 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                                 tableEntryRefreshContinuousFailureCeiling);
                             syncRefreshMetadata();
                             tableEntryRefreshContinuousFailureCount.set(0);
+                        } else if (e.isConnectInactive()) {
+                            // getMetaRefreshConnection failed, maybe the server is down, so we need to refresh metadata directly
+                            syncRefreshMetadata();
+                            tableEntryRefreshContinuousFailureCount.set(0);
                         }
                     } catch (Throwable t) {
                         RUNTIME.error("getOrRefreshTableEntry meet exception", t);
@@ -1414,6 +1418,10 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
                                     tableEntryRefreshContinuousFailureCeiling);
                             syncRefreshMetadata();
                             tableEntryRefreshContinuousFailureCount.set(0);
+                        } else if (e.isConnectInactive()) {
+                            // getMetaRefreshConnection failed, maybe the server is down, so we need to refresh metadata directly
+                            syncRefreshMetadata();
+                            tableEntryRefreshContinuousFailureCount.set(0);
                         }
                     } catch (Throwable t) {
                         RUNTIME.error("getOrRefreshTableEntry meet exception", t);
@@ -1504,9 +1512,15 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
             throw e;
         } catch (Exception e) {
             RUNTIME.error(LCD.convert("01-00020"), tableEntryKey, tableEntry, e);
-            throw new ObTableEntryRefreshException(String.format(
-                "failed to get table entry key=%s original tableEntry=%s ", tableEntryKey,
-                tableEntry), e);
+            if (e instanceof ObTableEntryRefreshException) {
+                throw new ObTableEntryRefreshException(String.format(
+                        "failed to get table entry key=%s original tableEntry=%s ", tableEntryKey,
+                        tableEntry), e, ((ObTableEntryRefreshException) e).isConnectInactive());
+            } else {
+                throw new ObTableEntryRefreshException(String.format(
+                        "failed to get table entry key=%s original tableEntry=%s ", tableEntryKey,
+                        tableEntry), e);
+            }
         }
         tableLocations.put(tableName, tableEntry);
         if (fetchAll) {

--- a/src/main/java/com/alipay/oceanbase/rpc/exception/ObTableEntryRefreshException.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/exception/ObTableEntryRefreshException.java
@@ -18,6 +18,8 @@
 package com.alipay.oceanbase.rpc.exception;
 
 public class ObTableEntryRefreshException extends ObTableException {
+    
+    private boolean connectInactive = false;
 
     /*
      * Ob table entry refresh exception.
@@ -52,7 +54,15 @@ public class ObTableEntryRefreshException extends ObTableException {
     public ObTableEntryRefreshException(String message, Throwable cause) {
         super(message, cause);
     }
+    
+    public ObTableEntryRefreshException(String message, Throwable cause, boolean connectInactive) {
+        super(message, cause);
+        this.connectInactive = connectInactive;
+    }
 
+    public boolean isConnectInactive() {
+        return connectInactive;
+    }
     /*
      * Ob table entry refresh exception.
      */


### PR DESCRIPTION

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Add an inactive state to RefreshException, set it only when JDBC connection fails.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
