### PR TITLE
fix client type odp mode

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -433,8 +433,9 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
 
         if (odpMode) {
             try {
+                ObTableClientType clientType = runningMode == RunningMode.HBASE ? ObTableClientType.JAVA_HBASE_CLIENT : ObTableClientType.JAVA_TABLE_CLIENT;
                 odpTable = new ObTable.Builder(odpAddr, odpPort) //
-                    .setLoginInfo(tenantName, fullUserName, password, database, getClientType(runningMode)) //
+                    .setLoginInfo(tenantName, fullUserName, password, database, clientType) //
                     .setProperties(getProperties()).setConfigs(TableConfigs).build();
             } catch (Exception e) {
                 logger


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
In the new version of the client, the HBase mode always sends ClientType3 to ODP, and ODP will rewrite the ClientType based on the cluster version to maintain compatibility.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
