### PR TITLE
fix obVersion in direct load

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/direct_load/ObDirectLoadConnection.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/direct_load/ObDirectLoadConnection.java
@@ -176,6 +176,7 @@ public class ObDirectLoadConnection {
 
     private void initProtocol() throws ObDirectLoadException {
         // 构造一个连接, 获取版本号
+        long obVersion = 0;
         ObTable table = null;
         synchronized (connectionFactory) { // 防止并发访问ObGlobal.OB_VERSION
             ObGlobal.OB_VERSION = 0;
@@ -191,8 +192,9 @@ public class ObDirectLoadConnection {
             } catch (Exception e) {
                 throw new ObDirectLoadException(e);
             }
+            obVersion = ObGlobal.OB_VERSION;
         }
-        this.protocol = ObDirectLoadProtocolFactory.getProtocol(traceId, ObGlobal.OB_VERSION);
+        this.protocol = ObDirectLoadProtocolFactory.getProtocol(traceId, obVersion);
         this.protocol.init();
         table.close();
     }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

It is not safe to access ObGlobal.OB_VERSION when creating ObDirectLoadConnection in parallel.

issue: https://github.com/oceanbase/obkv-table-client-java/issues/230

## Solution Description
<!-- Please clearly and concisely describe your solution. -->

access ObGlobal.OB_VERSION in synchronized