### PR TITLE
Fix odp set dirty

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/OdpInfo.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/OdpInfo.java
@@ -48,11 +48,11 @@ public class OdpInfo {
 
         this.obTable = new ObTable.Builder(addr, port) //
                 .setLoginInfo(tenantName, fullUserName, password, database, ObTableClientType.JAVA_TABLE_CLIENT) //
-                .setProperties(properties).setConfigs(tableConfigs).build();
+                .setProperties(properties).setConfigs(tableConfigs).setIsOdpMode(true).build();
         if (ObGlobal.isDistributedExecSupport() && runningMode == ObTableClient.RunningMode.HBASE) { // support distributed execute, login again
             this.obTable = new ObTable.Builder(addr, port)
                     .setLoginInfo(tenantName, fullUserName, password, database, ObTableClientType.JAVA_HBASE_CLIENT)
-                    .setProperties(properties).setConfigs(tableConfigs).build();
+                    .setProperties(properties).setConfigs(tableConfigs).setIsOdpMode(true).build();
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
In disaster recovery situation, if one of the servers gets unavailable for service, the new client will set the server as dirty and avoid to access to it again until it becomes available. But in odp mode, the client should not to set proxy's address as dirty, otherwise the proxy will never recover to valid.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
In odp mode, do not set dirty to proxy's address. Disaster recovery policy should be implemented by the odp side.