### PR TITLE
Fix table not exist retry too long in odp mode

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -191,7 +191,8 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                     } else {
                         logger.warn("meet exception when execute in odp mode." +
                                 "tablename: {}, errMsg: {}", indexTableName, e.getMessage());
-                        throw e;
+                        // odp mode do not retry any other exceptions
+                        throw new ObTableException(e);
                     }
                 } else {
                     needRefreshPartitionLocation = true;

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -389,6 +389,7 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
             } catch (Exception ex) {
                 needRefreshPartitionLocation = true;
                 if (obTableClient.isOdpMode()) {
+                    needRefreshPartitionLocation = false;
                     // if exceptions need to retry, retry to timeout
                     if (ex instanceof ObTableException
                         && ((ObTableException) ex).isNeedRetryError()) {

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -398,7 +398,8 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
                     } else {
                         logger.warn("meet exception when execute normal batch in odp mode."
                                     + "tablename: {}, errMsg: {}", tableName, ex.getMessage());
-                        throw ex;
+                        // odp mode do not retry any other exceptions
+                        throw new ObTableException(ex);
                     }
                 } else if (ex instanceof ObTableReplicaNotReadableException) {
                     if (System.currentTimeMillis() - startExecute < obTableClient

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -658,7 +658,8 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                     } else {
                         logger.warn("meet exception when execute ls batch in odp mode." +
                                 "tablename: {}, errMsg: {}", realTableName, ex.getMessage());
-                        throw ex;
+                        // odp mode do not retry any other exceptions
+                        throw new ObTableException(ex);
                     }
                 } else if (ex instanceof ObTableReplicaNotReadableException) {
                     if (System.currentTimeMillis() - startExecute < obTableClient.getRuntimeMaxWait()) {

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -651,6 +651,7 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
             } catch (Exception ex) {
                 needRefreshPartitionLocation = true;
                 if (obTableClient.isOdpMode()) {
+                    needRefreshPartitionLocation = false;
                     // if exceptions need to retry, retry to timeout
                     if (ex instanceof ObTableException && ((ObTableException) ex).isNeedRetryError()) {
                         logger.warn("meet need retry exception when execute ls batch in odp mode." +


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
In odp mode, table not exist error should be directly thrown and do not retry.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
Do not use retry-type exception to retry table not exist error in odp mode.