### PR TITLE
Fix odp mode use different exception to avoid retry

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/stream/ObTableClientQueryAsyncStreamResult.java
@@ -76,7 +76,7 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
                     referToNewPartition(firstEntry.getValue());
                     break;
                 } catch (Exception e) {
-                    if (e instanceof ObTableNeedFetchMetaException) {
+                    if (shouldRetry(e)) {
                         setExpectant(refreshPartition(this.asyncRequest.getObTableQueryRequest()
                             .getTableQuery(), client.getPhyTableNameFromTableGroup(entityType,
                             tableName)));
@@ -232,7 +232,7 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
                     // try access new partition, async will not remove useless expectant
                     referToLastStreamResult(lastEntry.getValue());
                 } catch (Exception e) {
-                    if (e instanceof ObTableNeedFetchMetaException) {
+                    if (shouldRetry(e)) {
                         String realTableName = client.getPhyTableNameFromTableGroup(entityType,
                             tableName);
                         TableEntry entry = client.getOrRefreshTableEntry(realTableName, false);
@@ -272,7 +272,7 @@ public class ObTableClientQueryAsyncStreamResult extends AbstractQueryStreamResu
                     // try access new partition, async will not remove useless expectant
                     referToNewPartition(entry.getValue());
                 } catch (Exception e) {
-                    if (e instanceof ObTableNeedFetchMetaException) {
+                    if (shouldRetry(e)) {
                         String realTableName = client.getPhyTableNameFromTableGroup(entityType,
                             tableName);
                         TableEntry tableEntry = client.getOrRefreshTableEntry(realTableName, false);

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -399,8 +399,7 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
                     } else {
                         logger.warn("meet exception when execute normal batch in odp mode."
                                     + "tablename: {}, errMsg: {}", tableName, ex.getMessage());
-                        // odp mode do not retry any other exceptions
-                        throw new ObTableException(ex);
+                        throw ex;
                     }
                 } else if (ex instanceof ObTableReplicaNotReadableException) {
                     if (System.currentTimeMillis() - startExecute < obTableClient
@@ -544,7 +543,7 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
     }
 
     private boolean shouldRetry(Throwable throwable) {
-        return throwable instanceof ObTableNeedFetchMetaException;
+        return !obTableClient.isOdpMode() && throwable instanceof ObTableNeedFetchMetaException;
     }
 
     private void executeWithRetries(ObTableOperationResult[] results, Map.Entry<Long, ObPair<ObTableParam, List<ObPair<Integer, ObTableOperation>>>> entry) throws Exception {

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -659,8 +659,7 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                     } else {
                         logger.warn("meet exception when execute ls batch in odp mode." +
                                 "tablename: {}, errMsg: {}", realTableName, ex.getMessage());
-                        // odp mode do not retry any other exceptions
-                        throw new ObTableException(ex);
+                        throw ex;
                     }
                 } else if (ex instanceof ObTableReplicaNotReadableException) {
                     if (System.currentTimeMillis() - startExecute < obTableClient.getRuntimeMaxWait()) {
@@ -823,7 +822,7 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
     }
 
     private boolean shouldRetry(Throwable throwable) {
-        return throwable instanceof ObTableNeedFetchMetaException;
+        return !obTableClient.isOdpMode() && throwable instanceof ObTableNeedFetchMetaException;
     }
 
     private void executeWithRetries(ObTableSingleOpResult[] results,


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Use different exception to avoid retry is not a good idea, because maybe the specific exception is depended outside.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
In odp mode, it will not retry in the table client judged by the mode inside.