### PR TITLE
Fix 431 version of ODP use normal get and throw error NOT_SUPPORT

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -946,7 +946,6 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
 
     /**
      * Get or refresh table entry meta information.
-     * work for both OcpMode and OdpMode
      * @param tableName table name
      * @return TableEntry
      * @throws Exception if fail
@@ -962,7 +961,6 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
 
     /**
      * refresh table meta information except location
-     * work for both OcpMode and OdpMode
      * @param tableName table name
      * */
     private TableEntry refreshMeta(String tableName) throws Exception {
@@ -971,12 +969,11 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
 
     /**
      * refresh table meta information except location
-     * work for both OcpMode and OdpMode
      * only support by ODP version after 4.3.2
      * @param tableName table name
      * */
     public TableEntry refreshOdpMeta(String tableName) throws Exception {
-        return tableRoute.refreshODPMeta(tableName, true);
+        return tableRoute.refreshOdpMeta(tableName, true);
     }
 
     /**
@@ -1087,13 +1084,12 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
      * only support by ODP version after 4.3.2
      * @param tableName table want to get
      * @param partId logic of table
-     * @param route ObServer route
      * @return ObPair of partId and table
      * @throws Exception exception
      */
-    public ObTableParam getOdpTableParamWithPartId(String tableName, long partId, ObServerRoute route)
+    public ObTableParam getOdpTableParamWithPartId(String tableName, long partId)
                                                                                                    throws Exception {
-        return tableRoute.getOdpTableWithPartId(tableName, partId, route);
+        return tableRoute.getOdpTableWithPartId(tableName, partId);
     }
 
     /**
@@ -1932,7 +1928,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         ObTableParam tableParam = null;
         if (odpMode) {
             if (refresh) {
-                tableRoute.refreshODPMeta(tableName, true);
+                tableRoute.refreshOdpMeta(tableName, true);
             }
             tableParam = tableRoute.getOdpTableParam(tableName, rowKey);
         } else {
@@ -1967,7 +1963,7 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
         List<ObTableParam> allTables;
         if (odpMode) {
             if (refresh) {
-                tableRoute.refreshODPMeta(tableName, true);
+                tableRoute.refreshOdpMeta(tableName, true);
             }
             allTables = tableRoute.getOdpTableParams(tableName, new ObTableQuery(), new Object[]{ ObObj.getMin() }, true,
                     new Object[]{ ObObj.getMax() }, true);

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/TableLocations.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/TableLocations.java
@@ -533,13 +533,14 @@ public class TableLocations {
 
     /**
      * fetch ODP partition meta information
+     * only support by ODP version after 4.3.2
      * @param tableName table name to query
      * @param forceRefresh flag to force ODP to fetch the latest partition meta information
      * @param odpTable odp table to execute refreshing
      * @return TableEntry ODPTableEntry
      * @throws Exception Exception
      */
-    public TableEntry refreshODPMeta(String tableName, boolean forceRefresh, ObTable odpTable)
+    public TableEntry refreshOdpMeta(String tableName, boolean forceRefresh, ObTable odpTable)
                                                                                               throws Exception {
         if (tableName == null || tableName.isEmpty()) {
             throw new IllegalArgumentException("table name is null");

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/TableRoute.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/TableRoute.java
@@ -102,20 +102,6 @@ public class TableRoute {
     }
 
     /**
-     * get ODP tableEntry by tableName,
-     * this methods will guarantee the tableEntry is not null
-     * only support by ODP version after 4.3.2
-     * */
-    public TableEntry getOdpTableEntry(String tableName) throws Exception {
-        TableEntry tableEntry;
-        tableEntry = odpTableLocations.getTableEntry(tableName);
-        if (tableEntry == null) {
-            tableEntry = refreshODPMeta(tableName, false);
-        }
-        return tableEntry;
-    }
-
-    /**
      * erase the tableEntry cached in tableLocations
      * */
     public void eraseTableEntry(String tableName) {
@@ -594,13 +580,6 @@ public class TableRoute {
         }
     }
 
-    /**
-     * get or refresh table meta information in odp mode
-     * */
-    public TableEntry refreshODPMeta(String tableName, boolean forceRefresh) throws Exception {
-        return odpTableLocations.refreshODPMeta(tableName, forceRefresh, odpInfo.getObTable());
-    }
-
     private Long[] getTabletsFromTableEntry(TableEntry tableEntry) {
         Long[] tablets = null;
         if (tableEntry.isPartitionTable()) {
@@ -628,7 +607,6 @@ public class TableRoute {
     }
     /**
      * get TableParam by tableName and rowkey
-     * work for both OcpMode and OdpMode
      * @param tableName tableName
      * @param rowkey row key or partition key names and values
      * @return ObTableParam tableParam
@@ -636,16 +614,6 @@ public class TableRoute {
     public ObTableParam getTableParam(String tableName, Row rowkey) throws Exception {
         ObServerRoute route = tableClient.getRoute(false);
         return getTableParamWithRoute(tableName, rowkey, route);
-    }
-
-    public ObTableParam getOdpTableParam(String tableName, Row rowkey) throws Exception {
-        TableEntry odpTableEntry = getOdpTableEntry(tableName);
-        if (odpTableEntry == null) {
-            logger.error("tableEntry is null, tableName: {}", tableName);
-            throw new ObTableEntryRefreshException("tableEntry is null, tableName: " + tableName);
-        }
-        long partId = getPartId(odpTableEntry, rowkey);
-        return getODPTableInternal(odpTableEntry, partId);
     }
 
     public ObTableParam getTableParamWithRoute(String tableName, Row rowkey, ObServerRoute route)
@@ -661,7 +629,6 @@ public class TableRoute {
 
     /**
      * get TableParam by tableName and rowkeys in batch
-     * work for both OcpMode and OdpMode
      * @param tableName tableName
      * @param rowkeys list of row key or partition key names and values
      * @return ObTableParam tableParam
@@ -727,7 +694,7 @@ public class TableRoute {
     }
 
     /**
-     * get addr by pardId
+     * get addr by partId
      * @param tableName table want to get
      * @param partId tabletId of table (real tablet id in 4.x)
      * @param route ObServer route
@@ -738,12 +705,6 @@ public class TableRoute {
                                                                                               throws Exception {
         TableEntry tableEntry = getTableEntry(tableName);
         return getTableInternal(tableName, tableEntry, partId, route);
-    }
-
-    public ObTableParam getOdpTableWithPartId(String tableName, long partId, ObServerRoute route)
-            throws Exception {
-        TableEntry tableEntry = getOdpTableEntry(tableName);
-        return getODPTableInternal(tableEntry, partId);
     }
 
     /**
@@ -818,24 +779,6 @@ public class TableRoute {
         ObTableParam param = createTableParam(obTable, tableEntry, obPartitionLocationInfo, partId,
             tabletId);
         addr.recordAccess();
-        return param;
-    }
-
-    /**
-     * get odp table entry by partId, just get meta information
-     * @param odpTableEntry odp tableEntry
-     * @param partId logicId of tablet
-     * @return ObTableParam table information for execution
-     */
-    private ObTableParam getODPTableInternal(TableEntry odpTableEntry, long partId) {
-        ObTable obTable = odpInfo.getObTable();
-        ObTableParam param = new ObTableParam(obTable);
-        param.setPartId(partId);
-        long tabletId = getTabletIdByPartId(odpTableEntry, partId);
-        param.setLsId(odpTableEntry.getPartitionEntry().getLsId(tabletId));
-        param.setTableId(odpTableEntry.getTableId());
-        // real partition(tablet) id
-        param.setPartitionId(tabletId);
         return param;
     }
 
@@ -975,7 +918,6 @@ public class TableRoute {
 
     /**
      * get TableParams by start-end range in this table
-     * work for both OcpMode and OdpMode
      * @param tableName table want to get
      * @param query query
      * @param start start key
@@ -990,14 +932,6 @@ public class TableRoute {
                                              boolean endInclusive) throws Exception {
         return getTablesInternal(tableName, query.getScanRangeColumns(), start, startInclusive,
             end, endInclusive, tableClient.getRoute(false));
-    }
-
-    public List<ObTableParam> getOdpTableParams(String tableName, ObTableQuery query, Object[] start,
-                                             boolean startInclusive, Object[] end,
-                                             boolean endInclusive) throws Exception {
-
-        return getODPTablesInternal(tableName, query.getScanRangeColumns(), start,
-                    startInclusive, end, endInclusive);
     }
 
     private List<ObTableParam> getTablesInternal(String tableName, List<String> scanRangeColumns,
@@ -1087,64 +1021,6 @@ public class TableRoute {
             params.add(param);
         }
         return params;
-    }
-
-    public List<ObTableParam> getODPTablesInternal(String tableName, List<String> scanRangeColumns,
-                                                   Object[] start, boolean startInclusive,
-                                                   Object[] end, boolean endInclusive)
-                                                                                      throws Exception {
-        if (start.length != end.length) {
-            throw new IllegalArgumentException("length of start key and end key is not equal");
-        }
-        List<ObTableParam> obTableParams = new ArrayList<ObTableParam>();
-        TableEntry odpTableEntry = getOdpTableEntry(tableName);
-
-        if (scanRangeColumns == null || scanRangeColumns.isEmpty()) {
-            Map<String, Integer> tableEntryRowKeyElement = tableClient.getRowKeyElement(tableName);
-            if (tableEntryRowKeyElement != null) {
-                scanRangeColumns = new ArrayList<String>(tableEntryRowKeyElement.keySet());
-            }
-        }
-        // 2. get replica location
-        // partIdWithReplicaList -> List<pair<logicId, replica>>
-        Row startRow = new Row();
-        Row endRow = new Row();
-        // ensure the format of column names and values if the current table is a table with partition
-        if (odpTableEntry.isPartitionTable()
-            && odpTableEntry.getPartitionInfo().getLevel() != ObPartitionLevel.LEVEL_ZERO) {
-            if ((scanRangeColumns == null || scanRangeColumns.isEmpty()) && start.length == 1
-                && start[0] instanceof ObObj && ((ObObj) start[0]).isMinObj() && end.length == 1
-                && end[0] instanceof ObObj && ((ObObj) end[0]).isMaxObj()) {
-                // for getPartition to query all partitions
-                scanRangeColumns = new ArrayList<String>(Collections.nCopies(start.length,
-                    "partition"));
-            }
-            // scanRangeColumn may be longer than start/end in prefix scanning situation
-            if (scanRangeColumns == null || scanRangeColumns.size() < start.length) {
-                throw new IllegalArgumentException(
-                    "length of key and scan range columns do not match, please use addRowKeyElement or set scan range columns");
-            }
-            for (int i = 0; i < start.length; i++) {
-                startRow.add(scanRangeColumns.get(i), start[i]);
-                endRow.add(scanRangeColumns.get(i), end[i]);
-            }
-        }
-
-        List<Long> partIds = getPartIds(odpTableEntry, startRow, startInclusive, endRow,
-            endInclusive);
-        for (Long partId : partIds) {
-            ObTable obTable = odpInfo.getObTable();
-            ObTableParam param = new ObTableParam(obTable);
-            param.setPartId(partId);
-            long tabletId = getTabletIdByPartId(odpTableEntry, partId);
-            param.setLsId(odpTableEntry.getPartitionEntry().getLsId(tabletId));
-            param.setTableId(odpTableEntry.getTableId());
-            // real partition(tablet) id
-            param.setPartitionId(tabletId);
-            obTableParams.add(param);
-        }
-
-        return obTableParams;
     }
 
     /**
@@ -1244,6 +1120,158 @@ public class TableRoute {
         }
 
         return partIds;
+    }
+
+    /*------------------------------------------------------------------------ODP routing------------------------------------------------------------------------*/
+
+    /**
+     * get ODP tableEntry by tableName,
+     * this methods will guarantee the tableEntry is not null
+     * only support by ODP version after 4.3.2
+     * */
+    public TableEntry getOdpTableEntry(String tableName) throws Exception {
+        TableEntry tableEntry;
+        tableEntry = odpTableLocations.getTableEntry(tableName);
+        if (tableEntry == null) {
+            tableEntry = refreshOdpMeta(tableName, false);
+        }
+        return tableEntry;
+    }
+
+    /**
+     * get or refresh table meta information in odp mode
+     * only support by ODP version after 4.3.2
+     * */
+    public TableEntry refreshOdpMeta(String tableName, boolean forceRefresh) throws Exception {
+        return odpTableLocations.refreshOdpMeta(tableName, forceRefresh, odpInfo.getObTable());
+    }
+
+    /**
+     * get odp TableParam by tableName and rowkey
+     * only support by ODP version after 4.3.2
+     * @param tableName tableName
+     * @param rowkey row key or partition key names and values
+     * @return ObTableParam tableParam
+     * */
+    public ObTableParam getOdpTableParam(String tableName, Row rowkey) throws Exception {
+        TableEntry odpTableEntry = getOdpTableEntry(tableName);
+        if (odpTableEntry == null) {
+            logger.error("tableEntry is null, tableName: {}", tableName);
+            throw new ObTableEntryRefreshException("tableEntry is null, tableName: " + tableName);
+        }
+        long partId = getPartId(odpTableEntry, rowkey);
+        return getOdpTableInternal(odpTableEntry, partId);
+    }
+
+    /**
+     * get odp table addr by partId
+     * only support by ODP version after 4.3.2
+     * @param tableName table want to get
+     * @param partId tabletId of table (real tablet id in 4.x)
+     * @return ObTableParam table information for execution
+     * @throws Exception exception
+     */
+    public ObTableParam getOdpTableWithPartId(String tableName, long partId)
+            throws Exception {
+        TableEntry tableEntry = getOdpTableEntry(tableName);
+        return getOdpTableInternal(tableEntry, partId);
+    }
+
+    /**
+     * get odp table entry by partId, just get meta information
+     * only support by ODP version after 4.3.2
+     * @param odpTableEntry odp tableEntry
+     * @param partId logicId of tablet
+     * @return ObTableParam table information for execution
+     */
+    private ObTableParam getOdpTableInternal(TableEntry odpTableEntry, long partId) {
+        ObTable obTable = odpInfo.getObTable();
+        ObTableParam param = new ObTableParam(obTable);
+        param.setPartId(partId);
+        long tabletId = getTabletIdByPartId(odpTableEntry, partId);
+        param.setLsId(odpTableEntry.getPartitionEntry().getLsId(tabletId));
+        param.setTableId(odpTableEntry.getTableId());
+        // real partition(tablet) id
+        param.setPartitionId(tabletId);
+        return param;
+    }
+
+    /**
+     * get odp TableParams by start-end range in this table
+     * only support by ODP version after 4.3.2
+     * @param tableName table want to get
+     * @param query query
+     * @param start start key
+     * @param startInclusive whether include start key
+     * @param end end key
+     * @param endInclusive whether include end key
+     * @return list of table obTableParams
+     * @throws Exception exception
+     */
+    public List<ObTableParam> getOdpTableParams(String tableName, ObTableQuery query, Object[] start,
+                                                boolean startInclusive, Object[] end,
+                                                boolean endInclusive) throws Exception {
+
+        return getOdpTablesInternal(tableName, query.getScanRangeColumns(), start,
+                startInclusive, end, endInclusive);
+    }
+
+    private List<ObTableParam> getOdpTablesInternal(String tableName, List<String> scanRangeColumns,
+                                                    Object[] start, boolean startInclusive,
+                                                    Object[] end, boolean endInclusive)
+            throws Exception {
+        if (start.length != end.length) {
+            throw new IllegalArgumentException("length of start key and end key is not equal");
+        }
+        List<ObTableParam> obTableParams = new ArrayList<ObTableParam>();
+        TableEntry odpTableEntry = getOdpTableEntry(tableName);
+
+        if (scanRangeColumns == null || scanRangeColumns.isEmpty()) {
+            Map<String, Integer> tableEntryRowKeyElement = tableClient.getRowKeyElement(tableName);
+            if (tableEntryRowKeyElement != null) {
+                scanRangeColumns = new ArrayList<String>(tableEntryRowKeyElement.keySet());
+            }
+        }
+        // 2. get replica location
+        // partIdWithReplicaList -> List<pair<logicId, replica>>
+        Row startRow = new Row();
+        Row endRow = new Row();
+        // ensure the format of column names and values if the current table is a table with partition
+        if (odpTableEntry.isPartitionTable()
+                && odpTableEntry.getPartitionInfo().getLevel() != ObPartitionLevel.LEVEL_ZERO) {
+            if ((scanRangeColumns == null || scanRangeColumns.isEmpty()) && start.length == 1
+                    && start[0] instanceof ObObj && ((ObObj) start[0]).isMinObj() && end.length == 1
+                    && end[0] instanceof ObObj && ((ObObj) end[0]).isMaxObj()) {
+                // for getPartition to query all partitions
+                scanRangeColumns = new ArrayList<String>(Collections.nCopies(start.length,
+                        "partition"));
+            }
+            // scanRangeColumn may be longer than start/end in prefix scanning situation
+            if (scanRangeColumns == null || scanRangeColumns.size() < start.length) {
+                throw new IllegalArgumentException(
+                        "length of key and scan range columns do not match, please use addRowKeyElement or set scan range columns");
+            }
+            for (int i = 0; i < start.length; i++) {
+                startRow.add(scanRangeColumns.get(i), start[i]);
+                endRow.add(scanRangeColumns.get(i), end[i]);
+            }
+        }
+
+        List<Long> partIds = getPartIds(odpTableEntry, startRow, startInclusive, endRow,
+                endInclusive);
+        for (Long partId : partIds) {
+            ObTable obTable = odpInfo.getObTable();
+            ObTableParam param = new ObTableParam(obTable);
+            param.setPartId(partId);
+            long tabletId = getTabletIdByPartId(odpTableEntry, partId);
+            param.setLsId(odpTableEntry.getPartitionEntry().getLsId(tabletId));
+            param.setTableId(odpTableEntry.getTableId());
+            // real partition(tablet) id
+            param.setPartitionId(tabletId);
+            obTableParams.add(param);
+        }
+
+        return obTableParams;
     }
 
     /*------------------------------------------------------------------------Table Group------------------------------------------------------------------------*/

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
@@ -193,7 +193,7 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
                     getPartId() != null && tableQuery.getIndexName() == null) {
                 ObServerRoute route = obTableClient.getRoute(false);
                 try {
-                    ObTableParam odpTable = obTableClient.getTableParamWithPartId(
+                    ObTableParam odpTable = obTableClient.getOdpTableParamWithPartId(
                             tableName, getPartId(), route);
                     partitionObTables.put(odpTable.getPartId(), new ObPair<>(odpTable.getPartId(), odpTable));
                 } catch (Exception e) {
@@ -204,8 +204,8 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
                                 "current ODP version does not support query with part id", e);
                         } else if (((ObTableException) e).getErrorCode() == ResultCodes.OB_ERR_KV_ROUTE_ENTRY_EXPIRE.errorCode) {
                             // retry table meta one time
-                            obTableClient.getOrRefreshTableEntry(tableName, true);
-                            ObTableParam odpTable = obTableClient.getTableParamWithPartId(
+                            obTableClient.refreshOdpMeta(tableName);
+                            ObTableParam odpTable = obTableClient.getOdpTableParamWithPartId(
                                     tableName, getPartId(), route);
                             partitionObTables.put(odpTable.getPartId(), new ObPair<>(odpTable.getPartId(), odpTable));
                         } else {

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientQueryImpl.java
@@ -191,10 +191,8 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
             }
             if (entityType != ObTableEntityType.HKV &&
                     getPartId() != null && tableQuery.getIndexName() == null) {
-                ObServerRoute route = obTableClient.getRoute(false);
                 try {
-                    ObTableParam odpTable = obTableClient.getOdpTableParamWithPartId(
-                            tableName, getPartId(), route);
+                    ObTableParam odpTable = obTableClient.getOdpTableParamWithPartId(tableName, getPartId());
                     partitionObTables.put(odpTable.getPartId(), new ObPair<>(odpTable.getPartId(), odpTable));
                 } catch (Exception e) {
                     if (e instanceof ObTableException) {
@@ -205,8 +203,7 @@ public class ObTableClientQueryImpl extends AbstractTableQueryImpl {
                         } else if (((ObTableException) e).getErrorCode() == ResultCodes.OB_ERR_KV_ROUTE_ENTRY_EXPIRE.errorCode) {
                             // retry table meta one time
                             obTableClient.refreshOdpMeta(tableName);
-                            ObTableParam odpTable = obTableClient.getOdpTableParamWithPartId(
-                                    tableName, getPartId(), route);
+                            ObTableParam odpTable = obTableClient.getOdpTableParamWithPartId(tableName, getPartId());
                             partitionObTables.put(odpTable.getPartId(), new ObPair<>(odpTable.getPartId(), odpTable));
                         } else {
                             throw e;


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
In new table client, the routing interfaces have been unified to the same for the ODP mode or OCP mode, but sometimes old versions of ODP cannot support new protocol of the routing process and there is no way to obtain the version of ODP in advance. So the routing interfaces have been separated, and the ODP routing interfaces are only used by getPartition relative methods.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
