### PR TITLE
fix IndexOutOfBoundsException when two same Get are in BatchOperation

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableSingleOpEntity.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/ObTableSingleOpEntity.java
@@ -410,7 +410,7 @@ public class ObTableSingleOpEntity extends AbstractPayload {
 
     public Map<String, Object> getSimpleProperties() {
         Map<String, Object> values = new HashMap<String, Object>((int) propertiesValues.size());
-        for (int i = 0; i < propertiesValues.size(); i++) {
+        for (int i = 0; i < propertiesNames.size(); i++) {
             values.put(propertiesNames.get(i), propertiesValues.get(i).getValue());
         }
         return values;

--- a/src/test/java/com/alipay/oceanbase/rpc/ObTableGetTest.java
+++ b/src/test/java/com/alipay/oceanbase/rpc/ObTableGetTest.java
@@ -19,6 +19,7 @@ package com.alipay.oceanbase.rpc;
 
 import com.alipay.oceanbase.rpc.exception.ObTableException;
 import com.alipay.oceanbase.rpc.get.Get;
+import com.alipay.oceanbase.rpc.get.result.GetResult;
 import com.alipay.oceanbase.rpc.mutation.BatchOperation;
 import com.alipay.oceanbase.rpc.mutation.result.BatchOperationResult;
 import com.alipay.oceanbase.rpc.util.ObTableClientTestUtil;
@@ -26,12 +27,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.alipay.oceanbase.rpc.mutation.MutationFactory.colVal;
 import static com.alipay.oceanbase.rpc.mutation.MutationFactory.row;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /*
 CREATE TABLE IF NOT EXISTS `test_get` (
@@ -273,5 +275,38 @@ public class ObTableGetTest {
 
         System.out.println(thrown.getMessage());
         assertTrue(thrown.getMessage().contains("[-4007][OB_NOT_SUPPORTED][operation is not supported to partially fill rowkey columns not supported]"));
+    }
+
+    /* test same Get */
+    @Test
+    public void testBatchGet6() throws Exception {
+        try {
+            // insert
+            client.insertOrUpdate(tableName)
+                    .setRowKey(row(colVal("c1", "c1_val"), colVal("c2", "c2_val")))
+                    .addMutateColVal(colVal("c3", "c3_val")).execute();
+
+            // select c1,c2
+            BatchOperation batch = client.batchOperation(tableName);
+            Get get1 = client.get(tableName)
+                    .setRowKey(row(colVal("c1", "c1_val"), colVal("c2", "c2_val"))).select("c1", "c2", "c3");
+            Get get2 = client.get(tableName)
+                    .setRowKey(row(colVal("c1", "c1_val"), colVal("c2", "c2_val"))).select("c1", "c2", "c3");
+            batch.addOperation(get1, get2);
+            BatchOperationResult res = batch.execute();
+            Assert.assertNotNull(res);
+            List<Object> getResults = res.getResults();
+            assertEquals(2, getResults.size());
+            for (Object result : getResults) {
+                GetResult getResult = (GetResult) result;
+                Map<String, Object> row = getResult.getOperationRow().getMap();
+                assertEquals("c1_val", row.get("c1"));
+                assertEquals("c2_val", row.get("c2"));
+                assertEquals("c3_val", row.get("c3"));
+            }
+        } finally {
+            client.delete(tableName).setRowKey(row(colVal("c1", "c1_val"), colVal("c2", "c2_val")))
+                    .execute();
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

- fix IndexOutOfBoundsException when two same Get are in BatchOperation


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
