### PR TITLE
Background keep-alive mechannic

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1182,14 +1182,14 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
     }
 
     public void dealWithRpcTimeoutForSingleTablet(ObServerAddr addr, String tableName, long tabletId) throws Exception {
-        tableRoute.refreshPartitionLocation(tableName, tabletId, null);
         RouteTableRefresher.SuspectObServer suspectAddr = new RouteTableRefresher.SuspectObServer(addr);
         RouteTableRefresher.addIntoSuspectIPs(suspectAddr);
+        tableRoute.refreshPartitionLocation(tableName, tabletId, null);
     }
     public void dealWithRpcTimeoutForBatchTablet(ObServerAddr addr, String tableName) throws Exception {
-        tableRoute.refreshTabletLocationBatch(tableName);
         RouteTableRefresher.SuspectObServer suspectAddr = new RouteTableRefresher.SuspectObServer(addr);
         RouteTableRefresher.addIntoSuspectIPs(suspectAddr);
+        tableRoute.refreshTabletLocationBatch(tableName);
     }
 
     /**

--- a/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObTableClient.java
@@ -1184,12 +1184,12 @@ public class ObTableClient extends AbstractObTableClient implements Lifecycle {
     public void dealWithRpcTimeoutForSingleTablet(ObServerAddr addr, String tableName, long tabletId) throws Exception {
         tableRoute.refreshPartitionLocation(tableName, tabletId, null);
         RouteTableRefresher.SuspectObServer suspectAddr = new RouteTableRefresher.SuspectObServer(addr);
-        tableRoute.addIntoSuspectIPs(suspectAddr);
+        RouteTableRefresher.addIntoSuspectIPs(suspectAddr);
     }
     public void dealWithRpcTimeoutForBatchTablet(ObServerAddr addr, String tableName) throws Exception {
         tableRoute.refreshTabletLocationBatch(tableName);
         RouteTableRefresher.SuspectObServer suspectAddr = new RouteTableRefresher.SuspectObServer(addr);
-        tableRoute.addIntoSuspectIPs(suspectAddr);
+        RouteTableRefresher.addIntoSuspectIPs(suspectAddr);
     }
 
     /**

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableConnection.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableConnection.java
@@ -116,8 +116,10 @@ public class ObTableConnection {
         MONITOR.info(logMessage(null, "CONNECT", endpoint, System.currentTimeMillis() - start));
 
         if (tries >= maxTryTimes) {
-            RouteTableRefresher.SuspectObServer suspectAddr = new RouteTableRefresher.SuspectObServer(obTable.getObServerAddr());
-            RouteTableRefresher.addIntoSuspectIPs(suspectAddr);
+            if (!obTable.isOdpMode()) {
+                RouteTableRefresher.SuspectObServer suspectAddr = new RouteTableRefresher.SuspectObServer(obTable.getObServerAddr());
+                RouteTableRefresher.addIntoSuspectIPs(suspectAddr);
+            }
             LOGGER.warn("connect failed after max " + maxTryTimes + " tries "
                         + TraceUtil.formatIpPort(obTable));
             throw new ObTableServerConnectException("connect failed after max " + maxTryTimes

--- a/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableConnection.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/bolt/transport/ObTableConnection.java
@@ -20,6 +20,7 @@ package com.alipay.oceanbase.rpc.bolt.transport;
 import com.alipay.oceanbase.rpc.ObGlobal;
 import com.alipay.oceanbase.rpc.exception.*;
 import com.alipay.oceanbase.rpc.location.LocationUtil;
+import com.alipay.oceanbase.rpc.location.model.RouteTableRefresher;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.login.ObTableLoginRequest;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.login.ObTableLoginResult;
 import com.alipay.oceanbase.rpc.table.ObTable;
@@ -115,6 +116,8 @@ public class ObTableConnection {
         MONITOR.info(logMessage(null, "CONNECT", endpoint, System.currentTimeMillis() - start));
 
         if (tries >= maxTryTimes) {
+            RouteTableRefresher.SuspectObServer suspectAddr = new RouteTableRefresher.SuspectObServer(obTable.getObServerAddr());
+            RouteTableRefresher.addIntoSuspectIPs(suspectAddr);
             LOGGER.warn("connect failed after max " + maxTryTimes + " tries "
                         + TraceUtil.formatIpPort(obTable));
             throw new ObTableServerConnectException("connect failed after max " + maxTryTimes
@@ -252,7 +255,7 @@ public class ObTableConnection {
         try {
             // 1. check the connection is available, force to close it
             if (checkAvailable()) {
-                LOGGER.warn("The connection would be closed and reconnected if: "
+                LOGGER.warn("The connection would be closed and reconnected is: "
                             + connection.getUrl());
                 close();
             }

--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -305,7 +305,7 @@ public class LocationUtil {
      * @param socketTimeout
      * @return
      */
-    private static String formatObServerUrl(ObServerAddr obServerAddr, long connectTimeout,
+    public static String formatObServerUrl(ObServerAddr obServerAddr, long connectTimeout,
                                             long socketTimeout) {
         return format(
             "jdbc:mysql://%s/oceanbase?useUnicode=true&characterEncoding=utf-8&connectTimeout=%d&socketTimeout=%d",
@@ -319,7 +319,7 @@ public class LocationUtil {
      * @return
      * @throws ObTableEntryRefreshException
      */
-    private static Connection getMetaRefreshConnection(String url, ObUserAuth sysUA)
+    public static Connection getMetaRefreshConnection(String url, ObUserAuth sysUA)
                                                                                     throws ObTableEntryRefreshException {
 
         try {

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/TableRoster.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/TableRoster.java
@@ -95,7 +95,7 @@ public class TableRoster {
 
             ObTable obTable = new ObTable.Builder(addr.getIp(), addr.getSvrPort()) //
                     .setLoginInfo(tenantName, userName, password, database, clientType) //
-                    .setProperties(properties).setConfigs(tableConfigs).build();
+                    .setProperties(properties).setConfigs(tableConfigs).setObServerAddr(addr).build();
             ObTable oldObTable = tables.putIfAbsent(addr, obTable);
             logger.warn("add new table addr, {}", addr.toString());
             if (oldObTable != null) { // maybe create two ob table concurrently, close current ob table

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/TableRoute.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/TableRoute.java
@@ -259,7 +259,7 @@ public class TableRoute {
                         tableClient.getClientType(runningMode))
                     //
                     .setProperties(tableClient.getProperties())
-                    .setConfigs(tableClient.getTableConfigs()).build();
+                    .setConfigs(tableClient.getTableConfigs()).setObServerAddr(addr).build();
                 addr2Table.put(addr, obTable);
                 servers.add(addr);
             } catch (Exception e) {
@@ -353,8 +353,23 @@ public class TableRoute {
     }
 
     public void launchRouteRefresher() {
-        routeRefresher = new RouteTableRefresher(tableClient);
+        routeRefresher = new RouteTableRefresher(tableClient, sysUA);
         routeRefresher.start();
+    }
+
+    public void removeObServer(ObServerAddr addr) {
+        logger.debug("remove useless table addr, {}", addr.toString());
+        ConcurrentHashMap<ObServerAddr, ObTable> tables = this.tableRoster.getTables();
+        ObTable table = tables.remove(addr);
+        if (table != null) {
+            table.close();
+        }
+        List<ObServerAddr> servers = this.serverRoster.getMembers();
+        servers.remove(addr);
+    }
+
+    public void addIntoSuspectIPs(RouteTableRefresher.SuspectObServer addr) throws Exception {
+        routeRefresher.addIntoSuspectIPs(addr);
     }
 
     /**

--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/TableRoute.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/TableRoute.java
@@ -368,10 +368,6 @@ public class TableRoute {
         servers.remove(addr);
     }
 
-    public void addIntoSuspectIPs(RouteTableRefresher.SuspectObServer addr) throws Exception {
-        routeRefresher.addIntoSuspectIPs(addr);
-    }
-
     /**
      * refresh all ob server synchronized, it will not refresh if last refresh time is 1 min ago
      * @param newRsList new root servers

--- a/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/protocol/payload/impl/execute/query/AbstractQueryStreamResult.java
@@ -290,10 +290,9 @@ public abstract class AbstractQueryStreamResult extends AbstractPayload implemen
                                 && ((ObTableTransportException) e).getErrorCode() == TransportCodes.BOLT_TIMEOUT) {
                                 logger.debug("query meet transport timeout, obTable ip:port is {}:{}",
                                         subObTable.getIp(), subObTable.getPort());
-                                client.syncRefreshMetadata(true);
                                 long tabletId = partIdWithIndex.getRight().getTabletId();
-                                client.refreshTableLocationByTabletId(indexTableName, tabletId);
                                 subObTable.setDirty();
+                                client.dealWithRpcTimeoutForSingleTablet(subObTable.getObServerAddr(), indexTableName, tabletId);
                             }
                             client.calculateContinuousFailure(indexTableName, e.getMessage());
                             throw e;

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTable.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTable.java
@@ -977,7 +977,7 @@ public class ObTable extends AbstractObTable implements Lifecycle {
                     }
                     connections[idx].reConnectAndLogin("expired");
                 } catch (Exception e) {
-                    log.warn("ObTableConnectionPool::checkAndReconnect reconnect fail {}. {}", connections[idx].getConnection().getUrl(), e.getMessage());
+                    log.warn("ObTableConnectionPool::checkAndReconnect reconnect fail {}:{}. {}", obTable.getIp(), obTable.getPort(), e.getMessage());
                 } finally {
                     connections[idx].setExpired(false);
                 }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTable.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTable.java
@@ -640,6 +640,10 @@ public class ObTable extends AbstractObTable implements Lifecycle {
         this.isOdpMode = isOdpMode;
     }
 
+    public boolean isOdpMode() {
+        return this.isOdpMode;
+    }
+
     public ObServerAddr getObServerAddr() {
         return this.addr;
     }

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTable.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTable.java
@@ -25,6 +25,7 @@ import com.alipay.oceanbase.rpc.bolt.transport.ObTableRemoting;
 import com.alipay.oceanbase.rpc.checkandmutate.CheckAndInsUp;
 import com.alipay.oceanbase.rpc.exception.*;
 import com.alipay.oceanbase.rpc.filter.ObTableFilter;
+import com.alipay.oceanbase.rpc.location.model.ObServerAddr;
 import com.alipay.oceanbase.rpc.mutation.*;
 import com.alipay.oceanbase.rpc.protocol.payload.ObPayload;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.*;
@@ -65,6 +66,7 @@ public class ObTable extends AbstractObTable implements Lifecycle {
     private ConnectionFactory     connectionFactory;
     private ObTableRemoting       realClient;
     private ObTableConnectionPool connectionPool;
+    private ObServerAddr          addr; // just used in background keep-alive
 
     private ObTableServerCapacity serverCapacity = new ObTableServerCapacity();
     
@@ -638,6 +640,14 @@ public class ObTable extends AbstractObTable implements Lifecycle {
         this.isOdpMode = isOdpMode;
     }
 
+    public ObServerAddr getObServerAddr() {
+        return this.addr;
+    }
+
+    public void setObServerAddr(ObServerAddr addr) {
+        this.addr = addr;
+    }
+
     public void setConfigs(Map<String, Object> configs) {
         this.configs = configs; 
     }
@@ -715,19 +725,20 @@ public class ObTable extends AbstractObTable implements Lifecycle {
 
     public static class Builder {
 
-        private String     ip;
-        private int        port;
+        private String       ip;
+        private int          port;
 
-        private String     tenantName;
-        private String     userName;
-        private String     password;
-        private String     database;
-        ObTableClientType  clientType;
+        private String       tenantName;
+        private String       userName;
+        private String       password;
+        private String       database;
+        private ObServerAddr addr = null; // only used in background keep-alive
+        ObTableClientType    clientType;
 
-        private Properties properties = new Properties();
+        private Properties   properties = new Properties();
         
         private Map<String, Object> tableConfigs = new HashMap<>();
-        private boolean    isOdpMode = false; // default as false
+        private boolean      isOdpMode = false; // default as false
 
         /*
          * Builder.
@@ -776,6 +787,11 @@ public class ObTable extends AbstractObTable implements Lifecycle {
             return this;
         }
 
+        public Builder setObServerAddr(ObServerAddr addr) {
+            this.addr = addr;
+            return this;
+        }
+
         /*
          * Build.
          */
@@ -791,6 +807,7 @@ public class ObTable extends AbstractObTable implements Lifecycle {
             obTable.setConfigs(tableConfigs);
             obTable.setClientType(clientType);
             obTable.setIsOdpMode(isOdpMode);
+            obTable.setObServerAddr(addr);
 
             obTable.init();
 

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientBatchOpsImpl.java
@@ -456,9 +456,8 @@ public class ObTableClientBatchOpsImpl extends AbstractTableBatchOps {
                             && ((ObTableTransportException) ex).getErrorCode() == TransportCodes.BOLT_TIMEOUT) {
                             logger.debug("normal batch meet transport timeout, obTable ip:port is {}:{}",
                                     subObTable.getIp(), subObTable.getPort());
-                            obTableClient.syncRefreshMetadata(true);
-                            obTableClient.refreshTableLocationByTabletId(tableName, partId);
                             subObTable.setDirty();
+                            obTableClient.dealWithRpcTimeoutForSingleTablet(subObTable.getObServerAddr(), tableName, partId);
                         }
                         obTableClient.calculateContinuousFailure(tableName, ex.getMessage());
                         throw ex;

--- a/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/table/ObTableClientLSBatchOpsImpl.java
@@ -732,9 +732,8 @@ public class ObTableClientLSBatchOpsImpl extends AbstractTableBatchOps {
                                 ((ObTableTransportException) ex).getErrorCode() == TransportCodes.BOLT_TIMEOUT) {
                             logger.debug("ls batch meet transport timeout, obTable ip:port is {}:{}",
                                     subObTable.getIp(), subObTable.getPort());
-                            obTableClient.syncRefreshMetadata(true);
-                            obTableClient.refreshTabletLocationBatch(realTableName);
                             subObTable.setDirty();
+                            obTableClient.dealWithRpcTimeoutForBatchTablet(subObTable.getObServerAddr(), realTableName);
                         }
                         obTableClient.calculateContinuousFailure(realTableName, ex.getMessage());
                         throw ex;


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
In low ops disaster recovery situation, table client need to remove the old observer connection in time. Otherwise when the observer recovers, netty connection may not identify the validity of the tcp connection and keep reporting error. Keep-alive mechanic guarantees to remove the old cache in time.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
