### PR TITLE
support hbase ddl from 4353 and before 440

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/ObGlobal.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/ObGlobal.java
@@ -114,7 +114,7 @@ public class ObGlobal {
     }
 
     public static boolean isHBaseAdminSupport() {
-        return OB_VERSION >= OB_VERSION_4_3_5_3;
+        return OB_VERSION >= OB_VERSION_4_3_5_3 && OB_VERSION < OB_VERSION_4_4_0_0;
     }
 
     public static boolean isCellTTLSupport() {
@@ -136,6 +136,8 @@ public class ObGlobal {
     public static final long OB_VERSION_4_3_5_2 = calcVersion(4, (short) 3, (byte) 5, (byte) 2);
 
     public static final long OB_VERSION_4_3_5_3 = calcVersion(4, (short) 3, (byte) 5, (byte) 3);
+
+    public static final long OB_VERSION_4_4_0_0 = calcVersion(4, (short) 4, (byte) 0, (byte) 0);
 
     public static long       OB_VERSION         = calcVersion(0, (short) 0, (byte) 0, (byte) 0);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Fix 440 observer not support getStartEndKey interface.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
