### PR TITLE
Fix debug log jackson range part error

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/location/model/TableLocations.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/model/TableLocations.java
@@ -27,6 +27,7 @@ import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObFetchPartitionMe
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObFetchPartitionMetaResult;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObFetchPartitionMetaType;
 import com.alipay.oceanbase.rpc.table.ObTable;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.slf4j.Logger;
 
 import java.util.Map;
@@ -43,6 +44,12 @@ import static com.alipay.oceanbase.rpc.util.TableClientLoggerFactory.*;
 public class TableLocations {
     private static final Logger       logger                                  = getLogger(TableLocations.class);
     private static final ObjectMapper objectMapper                            = new ObjectMapper();
+    static {
+        // FAIL_ON_EMPTY_BEANS means that whether throwing exception if there is no any serializable member with getter or setter in an object
+        // considering partitionElements in range partDesc is a list of Comparable interface and Comparable has no getter and setter
+        // we have to set this configuration as false because tableEntry may be serialized in debug log
+        objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    }
     private final ObTableClient       tableClient;
     private Map<String, Lock>         metaRefreshingLocks                     = new ConcurrentHashMap<String, Lock>();
     private Map<String, Lock>         locationBatchRefreshingLocks            = new ConcurrentHashMap<String, Lock>();


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Jackson cannot serialize ObPartitionKey in bounds of range part, need to disable FAIL_ON_EMPTY_BEANS.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
