### PR TITLE
Lower configServer error log level when throw out SocketTimeoutException

### DIFF
--- a/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
+++ b/src/main/java/com/alipay/oceanbase/rpc/location/LocationUtil.java
@@ -2332,7 +2332,7 @@ public class LocationUtil {
                 }
             } catch (Exception e) {
                 cause = e;
-                RUNTIME.error(LCD.convert("01-00017"), e);
+                RUNTIME.warn(LCD.convert("01-00017"), e);
                 Thread.sleep(retryInternal);
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Socket timeout error caused by HTTP GET ConfigServer content  is logged as an inappropriate level and may cause WARNING in production environment. Need to lower the log level of this situation because it's not that severe.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
